### PR TITLE
fix being able to remove an accidentally added fine tune

### DIFF
--- a/Editor/TextureTransformerEditor.cs
+++ b/Editor/TextureTransformerEditor.cs
@@ -55,7 +55,7 @@ namespace net.rs64.TexTransTool.Editor
         {
             EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button("+")) ArrayProperty.arraySize += 1;
-            EditorGUI.BeginDisabledGroup(ArrayProperty.arraySize <= 1);
+            EditorGUI.BeginDisabledGroup(ArrayProperty.arraySize < 1);
             if (GUILayout.Button("-")) ArrayProperty.arraySize -= 1;
             EditorGUI.EndDisabledGroup();
             EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
Now you can remove the first fine tune you add if you don't want it.