### PR TITLE
Fix: Glow types wrong alpha calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Glow系の合成のアルファの計算が正しくないのを修正 (#405)
+- Exclusion の計算式が調整されました (#405)
+
 ### Deprecated
 
 ## [0.6.0]

--- a/TexTransCore/BlendTexture/ShaderAsset/BlendColor.hlsl
+++ b/TexTransCore/BlendTexture/ShaderAsset/BlendColor.hlsl
@@ -96,13 +96,11 @@ float4 ColorBlend(float4 BaseColor, float4 AddColor) {
 #elif HardMix
   BlendColor = ( Acol + Bcol ) > 1.0 ;
 #elif AdditionGlow
-  float alpha = AddColor.a;
-  AddColor.a = 1;
-  BlendColor =  Bcol + (Acol * alpha);
+  BlendColor =  Bcol + (Acol * AddColor.a);
+  return float4(BlendColor,AlphaBlending(BaseColor,AddColor,BlendColor).a);
 #elif ColorDodgeGlow
-  float alpha = AddColor.a;
-  AddColor.a = 1;
-  BlendColor = Bcol / (1.0 - (Acol * alpha));
+  BlendColor = Bcol / (1.0 - (Acol * AddColor.a));
+  return float4(BlendColor,AlphaBlending(BaseColor,AddColor,BlendColor).a);
 #endif
 
   return AlphaBlending(BaseColor,AddColor,BlendColor);

--- a/TexTransCore/BlendTexture/ShaderAsset/BlendColor.hlsl
+++ b/TexTransCore/BlendTexture/ShaderAsset/BlendColor.hlsl
@@ -86,7 +86,7 @@ float4 ColorBlend(float4 BaseColor, float4 AddColor) {
 #elif Luminosity
   BlendColor = SetLum(Bcol,GetLum(Acol));
 #elif Exclusion
-  BlendColor = 0.5 - 2 * (Bcol - 0.5) * (Acol - 0.5);
+  BlendColor = Bcol + Acol - 2 * Bcol * Acol;
 #elif DarkenColorOnly
   BlendColor =  Bsum > Asum ?  Acol : Bcol;
 #elif LightenColorOnly


### PR DESCRIPTION
あと Exclusion の数式の変更。
フォトショ系にとりあえず準拠する方針で、クリスタの Exclusion は後で作る。