### PR TITLE
opti: メッシュデータの取り扱いを最適化

### DIFF
--- a/Editor/Decal/RealTimePreviewManager.cs
+++ b/Editor/Decal/RealTimePreviewManager.cs
@@ -9,6 +9,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Pool;
+using UnityEngine.Profiling;
 using static net.rs64.TexTransCore.BlendTexture.TextureBlend;
 
 namespace net.rs64.TexTransTool
@@ -250,17 +251,27 @@ namespace net.rs64.TexTransTool
 
             if (absDecalData.PropertyName != abstractDecal.TargetPropertyName
              || !absDecalData.RendererEqual(abstractDecal.GetRenderers))
-            { UnRegtAbstractDecal(abstractDecal); RegtAbstractDecal(abstractDecal); }
+            {
+                Profiler.BeginSample("Reregister decal");
+                UnRegtAbstractDecal(abstractDecal); RegtAbstractDecal(abstractDecal); 
+                Profiler.EndSample();
+            }
 
             if (absDecalData.BlendTypeKey != abstractDecal.BlendTypeKey)
             { absDecalData.SetBlendTypeKey(abstractDecal.BlendTypeKey); }
 
 
+            Profiler.BeginSample("Clear and compile decal");
             absDecalData.ClearDecalTarget();
             abstractDecal.CompileDecal(new TextureManager(true), absDecalData.decalTargets);
+            Profiler.EndSample();
 
             foreach (var mat in absDecalData.decalTargets.Keys)
-            { UpdatePreviewTexture(mat, absDecalData.PropertyName); }
+            {
+                Profiler.BeginSample("Update preview texture");
+                UpdatePreviewTexture(mat, absDecalData.PropertyName);
+                Profiler.EndSample();
+            }
         }
 
         public void PreviewForcesDecalUpdate()
@@ -377,8 +388,10 @@ namespace net.rs64.TexTransTool
 
                 public void ReviewReInit()
                 {
+                    Profiler.BeginSample("ReviewReInit");
                     TargetTexture.Clear();
                     Graphics.Blit(SouseTexture, TargetTexture);
+                    Profiler.EndSample();
                 }
 
                 public PreviewTexturePair(Texture2D souseTexture, RenderTexture targetTexture)

--- a/Runtime/Decal/AbstructSingleDecal.cs
+++ b/Runtime/Decal/AbstructSingleDecal.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using net.rs64.TexTransCore.Decal;
 using net.rs64.TexTransCore.Island;
 using net.rs64.TexTransTool.Utils;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransTool.Decal
 {
@@ -19,11 +20,15 @@ namespace net.rs64.TexTransTool.Decal
 
         internal override Dictionary<Material, RenderTexture> CompileDecal(ITextureManager textureManager, Dictionary<Material, RenderTexture> decalCompiledRenderTextures = null)
         {
+            Profiler.BeginSample("GetMultipleDecalTexture");
             RenderTexture mulDecalTexture = GetMultipleDecalTexture(textureManager, DecalTexture, Color);
+            Profiler.EndSample();
+            
             decalCompiledRenderTextures ??= new();
             foreach (var renderer in TargetRenderers)
             {
                 if (renderer == null) { continue; }
+                Profiler.BeginSample("CreateDecalTexture");
                 DecalUtility.CreateDecalTexture<SpaceConverter, UVDimension>(
                    renderer,
                    decalCompiledRenderTextures,
@@ -36,6 +41,7 @@ namespace net.rs64.TexTransTool.Decal
                    HighQualityPadding,
                    GetUseDepthOrInvert
                );
+               Profiler.EndSample();
             }
             RenderTexture.ReleaseTemporary(mulDecalTexture);
             return decalCompiledRenderTextures;

--- a/Runtime/Decal/NailEditor.cs
+++ b/Runtime/Decal/NailEditor.cs
@@ -80,9 +80,9 @@ namespace net.rs64.TexTransTool.Decal
             return spaceList;
         }
 
-        internal List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>> GetFilter()
+        internal List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>> GetFilter()
         {
-            return new List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>>
+            return new List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>>
             {
                 new TriangleFilterUtility.FarStruct(1, false),
                 new TriangleFilterUtility.NearStruct(0, true),

--- a/Runtime/Decal/SimpleDecal.cs
+++ b/Runtime/Decal/SimpleDecal.cs
@@ -28,9 +28,9 @@ namespace net.rs64.TexTransTool.Decal
             else { return new ParallelProjectionFilter<Vector2>(GetFilter()); }
         }
 
-        internal List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>> GetFilter()
+        internal List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>> GetFilter()
         {
-            var filters = new List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>>
+            var filters = new List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>>
             {
                 new TriangleFilterUtility.FarStruct(1, true),
                 new TriangleFilterUtility.NearStruct(0, true)

--- a/Runtime/ReferenceResolver/Decal/AbstractRayCastRendererResolver.cs
+++ b/Runtime/ReferenceResolver/Decal/AbstractRayCastRendererResolver.cs
@@ -3,6 +3,7 @@ using net.rs64.TexTransCore.Island;
 using net.rs64.TexTransTool.Decal;
 using UnityEngine;
 using net.rs64.TexTransCore.Decal;
+using net.rs64.TexTransCore.TransTextureCore;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
 
 namespace net.rs64.TexTransTool.ReferenceResolver.ATResolver
@@ -20,12 +21,12 @@ namespace net.rs64.TexTransTool.ReferenceResolver.ATResolver
             {
                 var souseMesh = renderer.GetMesh();
                 if (souseMesh == null) { continue; }
-                var vertex = DecalUtility.GetWorldSpaceVertices(renderer);
-                var triangle = souseMesh.GetTriangleIndex();
+
+                var meshdata = renderer.Memo(DecalUtility.GetMeshData);
 
                 var ray = new Ray(transform.position, transform.forward);
 
-                var hitTriangles = IslandCulling.RayCast(ray, vertex, triangle);
+                var hitTriangles = IslandCulling.RayCast(ray, meshdata);
 
                 var count = 0;
                 foreach (var hitTriangle in hitTriangles)

--- a/TexTransCore/BlendTexture/TextureBlend.cs
+++ b/TexTransCore/BlendTexture/TextureBlend.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using System;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransCore.BlendTexture
 {
@@ -201,14 +202,21 @@ namespace net.rs64.TexTransCore.BlendTexture
         public static void BlendBlit<BlendTex>(this RenderTexture baseRenderTexture, IEnumerable<BlendTex> adds)
         where BlendTex : IBlendTexturePair
         {
+            Profiler.BeginSample("BlendBlit");
             using (new RTActiveSaver())
             {
+                Profiler.BeginSample("Create material");
                 var material = new Material(BlendTexShader);
+                Profiler.EndSample();
+                
+                Profiler.BeginSample("Create RT");
                 var temRt = RenderTexture.GetTemporary(baseRenderTexture.descriptor);
+                Profiler.EndSample();
+                
                 var swap = baseRenderTexture;
                 var target = temRt;
                 Graphics.Blit(swap, target);
-
+                
                 foreach (var Add in adds)
                 {
                     if (Add == null || Add.Texture == null || Add.BlendTypeKey == null) { continue; }
@@ -226,6 +234,7 @@ namespace net.rs64.TexTransCore.BlendTexture
                 RenderTexture.ReleaseTemporary(temRt);
                 UnityEngine.Object.DestroyImmediate(material);
             }
+            Profiler.EndSample();
         }
         public static RenderTexture BlendBlit(Texture2D baseRenderTexture, Texture add, string blendTypeKey, RenderTexture targetRt = null)
         {

--- a/TexTransCore/Decal/DecalUtility.cs
+++ b/TexTransCore/Decal/DecalUtility.cs
@@ -6,35 +6,26 @@ using System.Linq;
 using UnityEngine;
 using net.rs64.TexTransCore.TransTextureCore;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
+using Unity.Collections;
+using Unity.Jobs;
 using UnityEngine.Pool;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransCore.Decal
 {
     public static class DecalUtility
     {
-        public interface IConvertSpace<UVDimension>
+        public interface IConvertSpace<UVDimension>: IDisposable
         where UVDimension : struct
         {
             void Input(MeshData meshData);
-            List<UVDimension> OutPutUV(List<UVDimension> output = null);
+            NativeArray<UVDimension> OutPutUV();
         }
         public interface ITrianglesFilter<SpaceConverter>
         {
             List<TriangleIndex> Filtering(SpaceConverter space, List<TriangleIndex> triangles, List<TriangleIndex> output = null);
         }
-        public class MeshData
-        {
-            internal readonly List<Vector3> Vertex;
-            internal readonly List<Vector2> UV;
-            internal readonly List<List<TriangleIndex>> TrianglesSubMesh;
 
-            internal MeshData(List<Vector3> vertex, List<Vector2> uV, List<List<TriangleIndex>> trianglesSubMesh)
-            {
-                Vertex = vertex;
-                UV = uV;
-                TrianglesSubMesh = trianglesSubMesh;
-            }
-        }
         internal static Dictionary<Material, RenderTexture> CreateDecalTexture<SpaceConverter, UVDimension>(
             Renderer targetRenderer,
             Dictionary<Material, RenderTexture> renderTextures,
@@ -52,14 +43,25 @@ namespace net.rs64.TexTransCore.Decal
         {
             if (renderTextures == null) renderTextures = new();
 
-            var vertices = GetWorldSpaceVertices(targetRenderer, ListPool<Vector3>.Get());
+            Profiler.BeginSample("GetMeshData");
+            var meshData = targetRenderer.Memo(GetMeshData);
+            Profiler.EndSample();
+            
             var targetMesh = targetRenderer.GetMesh();
+            
+            Profiler.BeginSample("GetUVs");
             var tUV = ListPool<Vector2>.Get(); targetMesh.GetUVs(0, tUV);
+            Profiler.EndSample();
+            
+            Profiler.BeginSample("GetPooledSubTriangle");
             var trianglesSubMesh = targetMesh.GetPooledSubTriangle();
+            Profiler.EndSample();
 
-            convertSpace.Input(new MeshData(vertices, tUV, trianglesSubMesh));
+            Profiler.BeginSample("convertSpace.Input");
+            convertSpace.Input(meshData);
+            Profiler.EndSample();
+            
             var sUVPooled = ListPool<UVDimension>.Get();
-            var sUV = convertSpace.OutPutUV(sUVPooled);
 
             var materials = targetRenderer.sharedMaterials;
 
@@ -75,7 +77,12 @@ namespace net.rs64.TexTransCore.Decal
 
                 List<TriangleIndex> filteredTriangle;
                 var filteredTrianglePooled = ListPool<TriangleIndex>.Get();
-                if (filter != null) { filteredTriangle = filter.Filtering(convertSpace, triangle, filteredTrianglePooled); }
+                if (filter != null)
+                {
+                    Profiler.BeginSample("Filtering");
+                    filteredTriangle = filter.Filtering(convertSpace, triangle, filteredTrianglePooled);
+                    Profiler.EndSample();
+                }
                 else { filteredTriangle = triangle; }
 
                 if (filteredTriangle.Any() == false) { continue; }
@@ -86,6 +93,9 @@ namespace net.rs64.TexTransCore.Decal
                     renderTextures.Add(targetMat, tempRt);
                 }
 
+                var sUV = convertSpace.OutPutUV();
+
+                Profiler.BeginSample("TransTexture.ForTrans");
                 TransTexture.ForTrans(
                     renderTextures[targetMat],
                     sousTextures,
@@ -95,27 +105,26 @@ namespace net.rs64.TexTransCore.Decal
                     highQualityPadding,
                     useDepthOrInvert
                 );
-
-
+                Profiler.EndSample();
+                
                 ListPool<TriangleIndex>.Release(filteredTrianglePooled);
             }
-            ListPool<Vector3>.Release(vertices);
             ListPool<Vector2>.Release(tUV);
             ListPool<UVDimension>.Release(sUVPooled);
             ReleasePooledSubTriangle(trianglesSubMesh);
 
             return renderTextures;
         }
-        internal static List<Vector3> GetWorldSpaceVertices(Renderer target, List<Vector3> outPut = null)
+        internal static MeshData GetMeshData(Renderer target)
         {
-            outPut?.Clear(); outPut ??= new List<Vector3>();
+            MeshData result;
             switch (target)
             {
                 case SkinnedMeshRenderer smr:
                     {
                         Mesh mesh = new Mesh();
                         smr.BakeMesh(mesh);
-                        mesh.GetVertices(outPut);
+                        
                         Matrix4x4 matrix;
                         if (smr.bones.Any())
                         {
@@ -129,15 +138,15 @@ namespace net.rs64.TexTransCore.Decal
                         {
                             matrix = smr.rootBone.localToWorldMatrix;
                         }
-                        ConvertVerticesInMatrix(matrix, outPut, Vector3.zero);
+
+                        result = new MeshData(mesh, matrix);
 
                         UnityEngine.Object.DestroyImmediate(mesh);
                         break;
                     }
                 case MeshRenderer mr:
                     {
-                        mr.GetComponent<MeshFilter>().sharedMesh.GetVertices(outPut);
-                        ConvertVerticesInMatrix(mr.localToWorldMatrix, outPut, Vector3.zero);
+                        return new MeshData(mr.GetComponent<MeshFilter>().sharedMesh, mr.localToWorldMatrix);
                         break;
                     }
                 default:
@@ -145,7 +154,7 @@ namespace net.rs64.TexTransCore.Decal
                         throw new System.ArgumentException("Rendererが対応したタイプではないか、TargetRendererが存在しません。");
                     }
             }
-            return outPut;
+            return result;
         }
         public static List<List<TriangleIndex>> GetPooledSubTriangle(this Mesh mesh)
         {
@@ -166,16 +175,36 @@ namespace net.rs64.TexTransCore.Decal
             ListPool<List<TriangleIndex>>.Release(subTriList);
         }
 
-        internal static List<Vector3> ConvertVerticesInMatrix(Matrix4x4 matrix, IEnumerable<Vector3> vertices, Vector3 offset, List<Vector3> outPut = null)
+        internal static NativeArray<Vector3> ConvertVerticesInMatrix(Matrix4x4 matrix, MeshData meshData, Vector3 offset, out JobHandle jobHandle)
         {
-            outPut?.Clear(); outPut ??= new List<Vector3>();
-            foreach (var vert in vertices)
+            var array = new NativeArray<Vector3>(meshData.Vertices.Length, Allocator.TempJob);
+
+            jobHandle = new ConvertVerticesJob()
             {
-                var pos = matrix.MultiplyPoint3x4(vert) + offset;
-                outPut.Add(pos);
-            }
-            return outPut;
+                InputVertices = meshData.Vertices,
+                OutputVertices = array,
+                Matrix = matrix,
+                Offset = offset
+            }.Schedule(meshData.Vertices.Length, 64);
+
+            meshData.AddJobDependency(jobHandle);
+
+            return array;
         }
+
+        private struct ConvertVerticesJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<Vector3> InputVertices;
+            [WriteOnly] public NativeArray<Vector3> OutputVertices;
+            public Matrix4x4 Matrix;
+            public Vector3 Offset;
+            
+            public void Execute(int index)
+            {
+                OutputVertices[index] = Matrix.MultiplyPoint3x4(InputVertices[index]) + Offset;
+            }
+        }
+
         internal static void ConvertVerticesInMatrix(Matrix4x4 matrix, List<Vector3> vertices, Vector3 Offset)
         {
             for (int i = 0; i < vertices.Count; i++)

--- a/TexTransCore/Decal/MeshData.cs
+++ b/TexTransCore/Decal/MeshData.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using net.rs64.TexTransCore.TransTextureCore;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace net.rs64.TexTransCore.Decal
+{
+    public class MeshData : IDisposable
+    {
+        internal NativeArray<Vector3> _vertices;
+        internal NativeArray<Vector3> Vertices
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _vertices;
+            }
+        }
+        
+        internal NativeArray<Vector2> VertexUV;
+
+        internal JobHandle _jobHandle, _destroyJobHandle;
+        internal readonly NativeArray<TriangleIndex>[] _triangles;
+        internal NativeArray<TriangleIndex>[] TriangleIndex
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _triangles;
+            }
+        }
+
+        internal readonly NativeArray<Triangle>[] _trianglePos;
+        internal NativeArray<Triangle>[] Triangles
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _trianglePos;
+            }
+        }
+
+        internal readonly NativeArray<Triangle> _combinedTriangles;
+        internal NativeArray<Triangle> CombinedTriangles
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _combinedTriangles;
+            }
+        }
+        
+        internal readonly NativeArray<TriangleIndex> _combinedTriangleIndex;
+        internal NativeArray<TriangleIndex> CombinedTriangleIndex
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _combinedTriangleIndex;
+            }
+        }
+
+        internal readonly NativeArray<(int, int)> _combinedTriangleToSubmeshIndexAndOffset;
+        internal NativeArray<(int, int)> CombinedTriangleToSubmeshIndexAndOffset
+        {
+            get
+            {
+                _jobHandle.Complete();
+                return _combinedTriangleToSubmeshIndexAndOffset;
+            }
+        }
+
+        public void Dispose()
+        {
+            _jobHandle.Complete();
+            _destroyJobHandle.Complete();
+            Vertices.Dispose();
+            VertexUV.Dispose();
+            foreach (var triangle in _triangles)
+            {
+                triangle.Dispose();
+            }
+            foreach (var triangle in _trianglePos)
+            {
+                triangle.Dispose();
+            }
+            _combinedTriangles.Dispose();
+            _combinedTriangleIndex.Dispose();
+        }
+
+        internal MeshData(Mesh mesh, Matrix4x4 worldSpaceTransform)
+        {
+            var meshDataArray = Mesh.AcquireReadOnlyMeshData(mesh);
+
+            var mainMesh = meshDataArray[0];
+
+            var vertexCount = mainMesh.vertexCount;
+            _vertices = new NativeArray<Vector3>(vertexCount, Allocator.TempJob);
+            VertexUV = new NativeArray<Vector2>(vertexCount, Allocator.TempJob);
+            
+            mainMesh.GetVertices(_vertices);
+            mainMesh.GetUVs(0, VertexUV);
+
+            var subMeshCount = mainMesh.subMeshCount;
+            _triangles = new NativeArray<TriangleIndex>[subMeshCount];
+            _trianglePos = new NativeArray<Triangle>[subMeshCount];
+            
+            JobHandle worldSpaceTransformJob = new WorldSpaceTransformJob()
+            {
+                PositionBuffer = _vertices,
+                WorldSpaceTransform = worldSpaceTransform
+            }.Schedule(vertexCount, 64);
+
+            int totalTris = 0;
+            for (int submesh = 0; submesh < subMeshCount; submesh++)
+            {
+                var desc = mainMesh.GetSubMesh(submesh);
+                totalTris += desc.indexCount / 3;
+            }
+            _combinedTriangleIndex = new NativeArray<TriangleIndex>(totalTris, Allocator.TempJob);
+            _combinedTriangles = new NativeArray<Triangle>(totalTris, Allocator.TempJob);
+            _combinedTriangleToSubmeshIndexAndOffset = new NativeArray<(int, int)>(totalTris, Allocator.TempJob);
+            
+            JobHandle jobHandle = default;
+            int combinedOffset = 0;
+            for (int submesh = 0; submesh < subMeshCount; submesh++)
+            {
+                var desc = mainMesh.GetSubMesh(submesh);
+                var indexCount = desc.indexCount;
+                
+                _triangles[submesh] = new NativeArray<TriangleIndex>(indexCount, Allocator.TempJob);
+                _trianglePos[submesh] = new NativeArray<Triangle>(indexCount / 3, Allocator.TempJob);
+                
+                var indexes = new NativeArray<int>(indexCount, Allocator.TempJob);
+                mainMesh.GetIndices(indexes, submesh);
+
+                var newHandle = new InitTriangleJob()
+                {
+                    SubmeshIndexBuffer = indexes,
+                    PositionBuffer = _vertices,
+                    TriangleIndexBuffer = _triangles[submesh],
+                    TrianglePosBuffer = _trianglePos[submesh],
+                }.Schedule(indexCount / 3, 64, worldSpaceTransformJob);
+
+                var copyHandle = new PackVerticesJob()
+                {
+                    srcIndex = _triangles[submesh],
+                    srcPos = _trianglePos[submesh],
+                    dstIndex = _combinedTriangleIndex.GetSubArray(combinedOffset, indexCount / 3),
+                    dstPos = _combinedTriangles.GetSubArray(combinedOffset, indexCount / 3),
+                    dstSubmeshIndexAndOffset =
+                        _combinedTriangleToSubmeshIndexAndOffset.GetSubArray(combinedOffset, indexCount / 3),
+                    submeshIndex = submesh,
+                    submeshOffset = combinedOffset
+                }.Schedule(indexCount / 3, 64, newHandle);
+                
+                jobHandle = JobHandle.CombineDependencies(jobHandle, copyHandle);
+                combinedOffset += indexCount / 3;
+            }
+            
+            _jobHandle = jobHandle;
+            _destroyJobHandle = jobHandle;
+            
+            meshDataArray.Dispose();
+        }
+
+        struct PackVerticesJob : IJobParallelFor
+        {
+            [ReadOnly] public NativeArray<TriangleIndex> srcIndex;
+            [ReadOnly] public NativeArray<Triangle> srcPos;
+            
+            [NativeDisableParallelForRestriction]
+            [NativeDisableContainerSafetyRestriction]
+            [WriteOnly] public NativeSlice<TriangleIndex> dstIndex;
+            [NativeDisableParallelForRestriction]
+            [NativeDisableContainerSafetyRestriction]
+            [WriteOnly] public NativeSlice<Triangle> dstPos;
+            [NativeDisableParallelForRestriction]
+            [NativeDisableContainerSafetyRestriction]
+            [WriteOnly] public NativeSlice<(int, int)> dstSubmeshIndexAndOffset;
+
+            public int submeshIndex;
+            public int submeshOffset;
+            
+            public void Execute(int index)
+            {
+                dstIndex[index] = srcIndex[index];
+                dstPos[index] = srcPos[index];
+
+                dstSubmeshIndexAndOffset[index] = (submeshIndex, submeshOffset);
+            }
+        }
+        
+        struct InitTriangleJob : IJobParallelFor
+        {
+            [DeallocateOnJobCompletion] [ReadOnly] public NativeArray<int> SubmeshIndexBuffer;
+            [ReadOnly] public NativeArray<Vector3> PositionBuffer;
+            
+            [WriteOnly] public NativeArray<TriangleIndex> TriangleIndexBuffer;
+            [WriteOnly] public NativeArray<Triangle> TrianglePosBuffer;
+            
+            public void Execute(int index)
+            {
+                var i = index * 3;
+                var triIndex = new TriangleIndex(SubmeshIndexBuffer[i], SubmeshIndexBuffer[i + 1], SubmeshIndexBuffer[i + 2]);
+                TriangleIndexBuffer[index] = triIndex;
+                
+                var triangle = new Triangle();
+                triangle.zero = PositionBuffer[triIndex.zero];
+                triangle.one = PositionBuffer[triIndex.one];
+                triangle.two = PositionBuffer[triIndex.two];
+                TrianglePosBuffer[index] = triangle;
+            }
+        }
+        
+        struct WorldSpaceTransformJob : IJobParallelFor
+        {
+            public NativeArray<Vector3> PositionBuffer;
+            public Matrix4x4 WorldSpaceTransform;
+
+            public void Execute(int index)
+            {
+                PositionBuffer[index] = WorldSpaceTransform.MultiplyPoint3x4(PositionBuffer[index]);
+            }
+        }
+
+        internal List<Vector3> VertexList => Vertices.Memo(arr => arr.ToList());
+        internal List<Vector2> UVList => VertexUV.Memo(arr => arr.ToList());
+        internal List<List<TriangleIndex>> TrianglesSubMeshList
+            => TriangleIndex.Memo(arr => arr.Select(subarr => subarr.ToList()).ToList());
+
+        public void AddJobDependency(JobHandle jobHandle)
+        {
+            _destroyJobHandle = JobHandle.CombineDependencies(_destroyJobHandle, jobHandle);
+        }
+    }
+}

--- a/TexTransCore/Decal/MeshData.cs.meta
+++ b/TexTransCore/Decal/MeshData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3c3a43fd2f4f42e38ab79bb44d56527f
+timeCreated: 1710494050

--- a/TexTransCore/Decal/ParallelProjection/IslandCullingPPFilter.cs
+++ b/TexTransCore/Decal/ParallelProjection/IslandCullingPPFilter.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 using net.rs64.TexTransCore.TransTextureCore;
 using net.rs64.TexTransCore.Island;
 using UnityEngine.Pool;
@@ -11,7 +12,7 @@ namespace net.rs64.TexTransCore.Decal
     {
         public List<IslandSelector> IslandSelectors;
 
-        public IslandCullingPPFilter(List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>> filters, List<IslandSelector> islandSelectors) : base(filters)
+        public IslandCullingPPFilter(List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>> filters, List<IslandSelector> islandSelectors) : base(filters)
         {
             IslandSelectors = islandSelectors;
         }
@@ -19,7 +20,7 @@ namespace net.rs64.TexTransCore.Decal
         public override List<TriangleIndex> Filtering(ParallelProjectionSpace space, List<TriangleIndex> triangles, List<TriangleIndex> output = null)
         {
             var cullied = ListPool<TriangleIndex>.Get();
-            triangles = Island.IslandCulling.Culling(IslandSelectors, space.MeshData.Vertex, space.MeshData.UV, triangles);
+            triangles = Island.IslandCulling.Culling(IslandSelectors, space.MeshData).Intersect(triangles).ToList();
             var result = base.Filtering(space, triangles, output);
             ListPool<TriangleIndex>.Release(cullied);
             return result;

--- a/TexTransCore/Decal/ParallelProjection/ParallelProjectionFilter.cs
+++ b/TexTransCore/Decal/ParallelProjection/ParallelProjectionFilter.cs
@@ -1,22 +1,23 @@
 using UnityEngine;
 using System.Collections.Generic;
 using net.rs64.TexTransCore.TransTextureCore;
+using net.rs64.TexTransTool.Utils;
 
 namespace net.rs64.TexTransCore.Decal
 {
     internal class ParallelProjectionFilter<UVDimension> : DecalUtility.ITrianglesFilter<ParallelProjectionSpace>
     where UVDimension : struct
     {
-        public List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>> Filters;
+        public List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>> Filters;
 
-        public ParallelProjectionFilter(List<TriangleFilterUtility.ITriangleFiltering<List<Vector3>>> filters)
+        public ParallelProjectionFilter(List<TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>> filters)
         {
             Filters = filters;
         }
 
         public virtual List<TriangleIndex> Filtering(ParallelProjectionSpace space, List<TriangleIndex> triangles, List<TriangleIndex> output = null)
         {
-            return TriangleFilterUtility.FilteringTriangle(triangles, space.PPSVert, Filters, output);
+            return TriangleFilterUtility.FilteringTriangle(triangles, space.OutPutUV().AsList(), Filters, output);
         }
     }
 }

--- a/TexTransCore/Decal/ParallelProjection/ParallelProjectionSpace.cs
+++ b/TexTransCore/Decal/ParallelProjection/ParallelProjectionSpace.cs
@@ -1,26 +1,40 @@
+using System;
 using UnityEngine;
 using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Jobs;
 
 namespace net.rs64.TexTransCore.Decal
 {
     public class ParallelProjectionSpace : DecalUtility.IConvertSpace<Vector3>
     {
         internal Matrix4x4 ParallelProjectionMatrix;
-        internal List<Vector3> PPSVert;
-        internal DecalUtility.MeshData MeshData;
+        internal MeshData MeshData;
+
+        private JobHandle _jobHandle;
+        private NativeArray<Vector3> PPSVert;
+        
         internal ParallelProjectionSpace(Matrix4x4 parallelProjectionMatrix)
         {
             ParallelProjectionMatrix = parallelProjectionMatrix;
 
         }
-        public void Input(DecalUtility.MeshData meshData)
+        public void Input(MeshData meshData)
         {
             MeshData = meshData;
-            PPSVert = DecalUtility.ConvertVerticesInMatrix(ParallelProjectionMatrix, meshData.Vertex as IEnumerable<Vector3>, new Vector3(0.5f, 0.5f, 0));
+            PPSVert = DecalUtility.ConvertVerticesInMatrix(ParallelProjectionMatrix, meshData, new Vector3(0.5f, 0.5f, 0), out _jobHandle);
         }
 
-        public List<Vector3> OutPutUV(List<Vector3> output = null) => PPSVert;
+        public NativeArray<Vector3> OutPutUV()
+        {
+            _jobHandle.Complete();
+            return PPSVert;
+        } 
 
+        public void Dispose()
+        {
+            MeshData?.Dispose();
+        }
     }
 }
 

--- a/TexTransCore/Decal/TriangleFilterUtility.cs
+++ b/TexTransCore/Decal/TriangleFilterUtility.cs
@@ -47,7 +47,7 @@ namespace net.rs64.TexTransCore.Decal
             return outPut;
         }
 
-        public struct SideStruct : ITriangleFiltering<List<Vector3>>
+        public struct SideStruct : ITriangleFiltering<IList<Vector3>>
         {
             public bool IsReverse;
 
@@ -56,12 +56,12 @@ namespace net.rs64.TexTransCore.Decal
                 IsReverse = isReverse;
             }
 
-            public bool Filtering(TriangleIndex targetTri, List<Vector3> vertex)
+            public bool Filtering(TriangleIndex targetTri, IList<Vector3> vertex)
             {
                 return SideCheck(targetTri, vertex, IsReverse);
             }
 
-            public static bool SideCheck(TriangleIndex targetTri, List<Vector3> vertex, bool isReverse = false)
+            public static bool SideCheck(TriangleIndex targetTri, IList<Vector3> vertex, bool isReverse = false)
             {
                 var ba = vertex[targetTri[1]] - vertex[targetTri[0]];
                 var ac = vertex[targetTri[0]] - vertex[targetTri[2]];
@@ -73,7 +73,7 @@ namespace net.rs64.TexTransCore.Decal
 
         }
 
-        public struct FarStruct : ITriangleFiltering<List<Vector3>>
+        public struct FarStruct : ITriangleFiltering<IList<Vector3>>
         {
             public float Far;
             public bool IsAllVertex;
@@ -84,11 +84,11 @@ namespace net.rs64.TexTransCore.Decal
                 IsAllVertex = isAllVertex;
             }
 
-            public bool Filtering(TriangleIndex targetTri, List<Vector3> vertex)
+            public bool Filtering(TriangleIndex targetTri, IList<Vector3> vertex)
             {
                 return FarClip(targetTri, vertex, Far, IsAllVertex);
             }
-            public static bool FarClip(TriangleIndex targetTri, List<Vector3> vertex, float far, bool isAllVertex)//IsAllVertexは排除されるのにすべてが条件に外れてる場合と一つでも条件に外れてる場合の選択
+            public static bool FarClip(TriangleIndex targetTri, IList<Vector3> vertex, float far, bool isAllVertex)//IsAllVertexは排除されるのにすべてが条件に外れてる場合と一つでも条件に外れてる場合の選択
             {
                 if (isAllVertex)
                 {
@@ -101,7 +101,7 @@ namespace net.rs64.TexTransCore.Decal
             }
         }
 
-        public struct NearStruct : TriangleFilterUtility.ITriangleFiltering<List<Vector3>>
+        public struct NearStruct : TriangleFilterUtility.ITriangleFiltering<IList<Vector3>>
         {
             public float Near;
             public bool IsAllVertex;
@@ -112,11 +112,11 @@ namespace net.rs64.TexTransCore.Decal
                 IsAllVertex = isAllVertex;
             }
 
-            public bool Filtering(TriangleIndex targetTri, List<Vector3> vertex)
+            public bool Filtering(TriangleIndex targetTri, IList<Vector3> vertex)
             {
                 return NearClip(targetTri, vertex, Near, IsAllVertex);
             }
-            public static bool NearClip(TriangleIndex targetTri, List<Vector3> vertex, float near, bool isAllVertex)
+            public static bool NearClip(TriangleIndex targetTri, IList<Vector3> vertex, float near, bool isAllVertex)
             {
                 if (isAllVertex)
                 {
@@ -129,7 +129,7 @@ namespace net.rs64.TexTransCore.Decal
             }
         }
 
-        public struct OutOfPolygonStruct : ITriangleFiltering<List<Vector3>>
+        public struct OutOfPolygonStruct : ITriangleFiltering<IList<Vector3>>
         {
             public PolygonCulling PolygonCulling;
             public float MinRange;
@@ -144,7 +144,7 @@ namespace net.rs64.TexTransCore.Decal
                 IsAllVertex = isAllVertex;
             }
 
-            public bool Filtering(TriangleIndex targetTri, List<Vector3> vertex)
+            public bool Filtering(TriangleIndex targetTri, IList<Vector3> vertex)
             {
                 switch (PolygonCulling)
                 {
@@ -159,7 +159,7 @@ namespace net.rs64.TexTransCore.Decal
 
             }
 
-            public static bool OutOfPolygonVertexBase(TriangleIndex targetTri, List<Vector3> vertex, float maxRange, float minRange, bool isAllVertex)
+            public static bool OutOfPolygonVertexBase(TriangleIndex targetTri, IList<Vector3> vertex, float maxRange, float minRange, bool isAllVertex)
             {
                 Span<bool> outOfPolygon = stackalloc bool[3] { false, false, false };
                 for (var index = 0; 3 > index; index += 1)
@@ -170,7 +170,7 @@ namespace net.rs64.TexTransCore.Decal
                 if (isAllVertex) return outOfPolygon[0] && outOfPolygon[1] && outOfPolygon[2];
                 else return outOfPolygon[0] || outOfPolygon[1] || outOfPolygon[2];
             }
-            public static bool OutOfPolygonEdgeBase(TriangleIndex targetTri, List<Vector3> Vertex, float maxRange, float minRange, bool isAllVertex)
+            public static bool OutOfPolygonEdgeBase(TriangleIndex targetTri, IList<Vector3> Vertex, float maxRange, float minRange, bool isAllVertex)
             {
                 float centerPos = Mathf.Lerp(maxRange, minRange, 0.5f);
                 var centerPosVec2 = new Vector2(centerPos, centerPos);
@@ -187,7 +187,7 @@ namespace net.rs64.TexTransCore.Decal
                 if (isAllVertex) return outOfPolygon[0] && outOfPolygon[1] && outOfPolygon[2];
                 else return outOfPolygon[0] || outOfPolygon[1] || outOfPolygon[2];
             }
-            public static bool OutOfPolygonEdgeEdgeAndCenterRayCast(TriangleIndex targetTri, List<Vector3> vertex, float maxRange, float minRange, bool isAllVertex)
+            public static bool OutOfPolygonEdgeEdgeAndCenterRayCast(TriangleIndex targetTri, IList<Vector3> vertex, float maxRange, float minRange, bool isAllVertex)
             {
                 float centerPos = Mathf.Lerp(maxRange, minRange, 0.5f);
                 var centerPosVec2 = new Vector2(centerPos, centerPos);

--- a/TexTransCore/Island/IslandUtility.cs
+++ b/TexTransCore/Island/IslandUtility.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using System.Collections;
+using net.rs64.TexTransCore.Decal;
 using net.rs64.TexTransCore.TransTextureCore;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
+using net.rs64.TexTransTool.Utils;
 using UnityEngine.Pool;
 using UnityEngine.Profiling;
 
@@ -98,28 +98,32 @@ namespace net.rs64.TexTransCore.Island
                 island.triangles.Add(idx);
             }
         }
+
+        public static List<Island> UVtoIsland(MeshData meshData)
+        {
+            return UVtoIsland(meshData.CombinedTriangleIndex.AsList(), meshData.VertexUV.AsList());
+        }
         
-        public static List<Island> UVtoIsland(List<TriangleIndex> triangles, List<Vector2> uv)
+        public static List<Island> UVtoIsland(IList<TriangleIndex> triIndexes, IList<Vector2> vertexUV)
         {
             Profiler.BeginSample("UVtoIsland");
-            var islands = UVToIslandImpl(triangles, uv);
+            var islands = UVToIslandImpl(triIndexes, vertexUV);
             Profiler.EndSample();
          
             return islands;
         }
 
-        private static List<Island> UVToIslandImpl(IEnumerable<TriangleIndex> trianglesIn, List<Vector2> uvs)
+        private static List<Island> UVToIslandImpl(IList<TriangleIndex> triIndexes, IList<Vector2> vertexUV)
         {
             int uniqueUv = 0;
-            List<Vector2> indexToUv = new List<Vector2>(uvs.Count);
-            Dictionary<Vector2, int> uvToIndex = new Dictionary<Vector2, int>(uvs.Count);
-            List<int> inputVertToUniqueIndex = new List<int>(uvs.Count);
-            
-            var trianglesList = (trianglesIn as List<TriangleIndex>) ?? new List<TriangleIndex>(trianglesIn);
+            var vertCount = vertexUV.Count;
+            List<Vector2> indexToUv = new List<Vector2>(vertCount);
+            Dictionary<Vector2, int> uvToIndex = new Dictionary<Vector2, int>(vertCount);
+            List<int> inputVertToUniqueIndex = new List<int>(vertCount);
 
             // 同一の位置にある頂点をまず調べて、共通のインデックスを割り当てます
             Profiler.BeginSample("Preprocess vertices");
-            foreach (var uv in uvs)
+            foreach (var uv in vertexUV)
             {
                 if (!uvToIndex.TryGetValue(uv, out var uvVert))
                 {
@@ -142,7 +146,7 @@ namespace net.rs64.TexTransCore.Island
             Profiler.EndSample();
 
             Profiler.BeginSample("Merge vertices");
-            foreach (var tri in trianglesList)
+            foreach (var tri in triIndexes)
             {
                 int idx_a = inputVertToUniqueIndex[tri.zero];
                 int idx_b = inputVertToUniqueIndex[tri.one];
@@ -161,11 +165,11 @@ namespace net.rs64.TexTransCore.Island
             
             // この時点で代表が決まっているので、三角を追加していきます。
             Profiler.BeginSample("Add triangles to islands");
-            for (int i = 0; i < trianglesList.Count; i++)
+            foreach (var tri in triIndexes)
             {
-                int idx = inputVertToUniqueIndex[trianglesList[i].zero];
+                int idx = inputVertToUniqueIndex[tri.zero];
 
-                nodes[VertNode.Find(nodes, idx)].AddTriangle(trianglesList[i], islands);
+                nodes[VertNode.Find(nodes, idx)].AddTriangle(tri, islands);
             }
             Profiler.EndSample();
 

--- a/TexTransCore/Memoize.cs
+++ b/TexTransCore/Memoize.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEditor;
+
+namespace net.rs64.TexTransCore.TransTextureCore
+{
+    internal static class FrameMemoEvents
+    {
+        internal static event Action OnClearMemo;
+
+        [InitializeOnLoadMethod]
+        static void Init()
+        {
+            EditorApplication.update += () =>
+            {
+                OnClearMemo?.Invoke();
+                OnClearMemo = default;
+            };
+        }
+    }
+
+    public static class Memoize
+    {
+        private static Dictionary<(object, object), (object, Action)> MemoData = new();
+        
+        /// <summary>
+        /// 変換関数の結果を一フレームだけ記憶するヘルパーです。同じoriginalとtransformを再度渡せば、計算結果を使いまわします。
+        /// </summary>
+        /// <param name="original">変換前のデータ</param>
+        /// <param name="transform">変換関数</param>
+        /// <param name="destroy">変換結果を破棄するデストラクター</param>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="U"></typeparam>
+        /// <returns></returns>
+        public static U Memo<T, U>(this T original, Func<T, U> transform, Action<U> destroy = null)
+        {
+            var memoKey = (original, transform);
+
+            if (MemoData.TryGetValue(memoKey, out var value))
+            {
+                return (U)value.Item1;
+            }
+            else
+            {
+                if (MemoData.Count == 0)
+                {
+                    FrameMemoEvents.OnClearMemo += () =>
+                    {
+                        foreach (var entry in MemoData)
+                        {
+                            entry.Value.Item2();
+                        }
+                        MemoData.Clear();
+                    };
+                }
+                
+                var output = transform(original);
+                MemoData[memoKey] = (output, () => destroy?.Invoke(output));
+                return output;
+            }
+        }
+    }
+}

--- a/TexTransCore/Memoize.cs.meta
+++ b/TexTransCore/Memoize.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 86bf31f28ebc46d48cd8a9e0f8cf255b
+timeCreated: 1710491746

--- a/TexTransCore/NativeArrayListView.cs
+++ b/TexTransCore/NativeArrayListView.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Collections;
+
+namespace net.rs64.TexTransTool.Utils
+{
+    internal static class NativeArrayListView
+    {
+        /// <summary>
+        /// コピーせずに、NativeArrayをIListとして扱うための拡張メソッドです。アイテムを削除・追加する関数は実装されていないため、
+        /// NotImplementedExceptionが発生します。
+        /// </summary>
+        /// <param name="array"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        internal static IList<T> AsList<T>(this NativeArray<T> array) where T : struct => new NativeArrayAsList<T>(array);
+        
+        internal class NativeArrayAsList<T> : IList<T> where T : struct
+        {
+            private NativeArray<T> _array;
+            
+            public NativeArrayAsList(NativeArray<T> array)
+            {
+                _array = array;
+            }
+            
+            public IEnumerator<T> GetEnumerator()
+            {
+                return _array.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void Add(T item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Contains(T item)
+            {
+                return _array.Contains(item);
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                for (int i = 0; i < _array.Length; i++)
+                {
+                    array[i + arrayIndex] = _array[i];
+                }
+            }
+
+            public bool Remove(T item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public int Count => _array.Length;
+            public bool IsReadOnly => true;
+            
+            public int IndexOf(T item)
+            {
+                return _array.Select((v, i) => (v, i))
+                    .Where(pair => pair.v.Equals(item))
+                    .Select(pair => pair.i)
+                    .Append(-1)
+                    .First();
+            }
+
+            public void Insert(int index, T item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public T this[int index]
+            {
+                get => _array[index];
+                set => _array[index] = value;
+            }
+        }
+    }
+}

--- a/TexTransCore/NativeArrayListView.cs.meta
+++ b/TexTransCore/NativeArrayListView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: db88eb9d8aa549c1a53a6ee8d132bb0a
+timeCreated: 1710496878


### PR DESCRIPTION
一部Renderer依存の計算結果が繰り返し計算される（UVtoIslandなど）ので、
その結果を一フレームだけキャッシュするように変更。

そのほか、メッシュデータをNativeArrayのままで取り出して扱えるような
基盤を作りました。Listとして扱っているところはまだ多く残っているけど、
これを徐々に切り替えていけば早くなると思います。
