### PR TITLE
opti: optimize GenerateTransMesh

### DIFF
--- a/TexTransCore/Decal/MeshData.cs
+++ b/TexTransCore/Decal/MeshData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using net.rs64.TexTransCore.TransTextureCore;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
@@ -168,6 +169,7 @@ namespace net.rs64.TexTransCore.Decal
             meshDataArray.Dispose();
         }
 
+        [BurstCompile]
         struct PackVerticesJob : IJobParallelFor
         {
             [ReadOnly] public NativeArray<TriangleIndex> srcIndex;
@@ -195,6 +197,7 @@ namespace net.rs64.TexTransCore.Decal
             }
         }
         
+        [BurstCompile]
         struct InitTriangleJob : IJobParallelFor
         {
             [DeallocateOnJobCompletion] [ReadOnly] public NativeArray<int> SubmeshIndexBuffer;
@@ -217,6 +220,7 @@ namespace net.rs64.TexTransCore.Decal
             }
         }
         
+        [BurstCompile]
         struct WorldSpaceTransformJob : IJobParallelFor
         {
             public NativeArray<Vector3> PositionBuffer;

--- a/TexTransCore/Island/IslandUtility.cs
+++ b/TexTransCore/Island/IslandUtility.cs
@@ -322,7 +322,7 @@ namespace net.rs64.TexTransCore.Island
             return new Vector2(uvScaleValue, uvScaleValue).magnitude / islandRect.Size.magnitude;
         }
 
-        public static List<Vector2> GenerateRectVertexes<TIslandRect>(this TIslandRect islandRect, float rectScalePadding = 0.1f, List<Vector2> outPutQuad = null)
+        public static IEnumerable<Vector2> GenerateRectVertexes<TIslandRect>(this TIslandRect islandRect, float rectScalePadding = 0.1f, List<Vector2> outPutQuad = null)
         where TIslandRect : IIslandRect
         {
             outPutQuad?.Clear(); outPutQuad ??= new();
@@ -335,20 +335,18 @@ namespace net.rs64.TexTransCore.Island
 
             if (!islandRect.Is90Rotation)
             {
-                outPutQuad.Add(new(leftDown.x - paddingVector.x, leftDown.y - paddingVector.y));
-                outPutQuad.Add(new(leftDown.x - paddingVector.x, rightUp.y + paddingVector.y));
-                outPutQuad.Add(new(rightUp.x + paddingVector.x, rightUp.y + paddingVector.y));
-                outPutQuad.Add(new(rightUp.x + paddingVector.x, leftDown.y - paddingVector.y));
+                yield return (new(leftDown.x - paddingVector.x, leftDown.y - paddingVector.y));
+                yield return (new(leftDown.x - paddingVector.x, rightUp.y + paddingVector.y));
+                yield return (new(rightUp.x + paddingVector.x, rightUp.y + paddingVector.y));
+                yield return (new(rightUp.x + paddingVector.x, leftDown.y - paddingVector.y));
             }
             else
             {
-                outPutQuad.Add(new(leftDown.x - paddingVector.x, rightUp.y + paddingVector.y));
-                outPutQuad.Add(new(rightUp.x + paddingVector.x, rightUp.y + paddingVector.y));
-                outPutQuad.Add(new(rightUp.x + paddingVector.x, leftDown.y - paddingVector.y));
-                outPutQuad.Add(new(leftDown.x - paddingVector.x, leftDown.y - paddingVector.y));
+                yield return (new(leftDown.x - paddingVector.x, rightUp.y + paddingVector.y));
+                yield return (new(rightUp.x + paddingVector.x, rightUp.y + paddingVector.y));
+                yield return (new(rightUp.x + paddingVector.x, leftDown.y - paddingVector.y));
+                yield return (new(leftDown.x - paddingVector.x, leftDown.y - paddingVector.y));
             }
-
-            return outPutQuad;
         }
     }
 


### PR DESCRIPTION
メッシュデータの変換・生成をBurstに切り替えました。テストアバター（SimpleDecal
x 8）では、ForTransの合計処理時間が17.14 ms ->
1.90msに短縮されました。
