### PR TITLE
opti: テクスチャ作成とリードバックを並行処理する

### DIFF
--- a/Editor/Domain/ProgressHandler.cs
+++ b/Editor/Domain/ProgressHandler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransTool
 {
@@ -8,11 +9,13 @@ namespace net.rs64.TexTransTool
         List<string> _progressDepth = new List<string>();
         public void ProgressStateEnter(string enterName)
         {
+            Profiler.BeginSample(enterName);
             _progressDepth.Add(enterName);
         }
 
         public void ProgressStateExit()
         {
+            Profiler.EndSample();
             _progressDepth.RemoveAt(_progressDepth.Count - 1);
         }
 

--- a/Editor/PreviewContext.cs
+++ b/Editor/PreviewContext.cs
@@ -6,6 +6,7 @@ using net.rs64.TexTransTool.CustomPreview;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.Profiling;
 using Object = UnityEngine.Object;
 
 namespace net.rs64.TexTransTool
@@ -97,8 +98,11 @@ namespace net.rs64.TexTransTool
             AnimationMode.BeginSampling();
             try
             {
+                Profiler.BeginSample("TexTransBehaviorApply: " + targetTTBehavior.GetType() + " " + targetTTBehavior.gameObject.name);
                 RenderersDomain previewDomain = null;
+                Profiler.BeginSample("FindMarker");
                 var marker = DomainMarkerFinder.FindMarker(targetTTBehavior.gameObject);
+                Profiler.EndSample();
                 if (marker != null) { previewDomain = new AvatarDomain(marker, true, false, true); }
                 else { previewDomain = new RenderersDomain(targetTTBehavior.GetRenderers, true, false, true); }
 
@@ -108,6 +112,7 @@ namespace net.rs64.TexTransTool
             }
             finally
             {
+                Profiler.EndSample();
                 AnimationMode.EndSampling();
             }
 

--- a/Runtime/TextureAtlas/AtlasShaderSupport/AtlasShaderSupportUtils.cs
+++ b/Runtime/TextureAtlas/AtlasShaderSupport/AtlasShaderSupportUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
 using UnityEngine;
+using UnityEngine.Profiling;
 using TexLU = net.rs64.TexTransCore.BlendTexture.TextureBlend;
 using TexUT = net.rs64.TexTransCore.TransTextureCore.Utils.TextureUtility;
 
@@ -16,8 +17,10 @@ namespace net.rs64.TexTransTool.TextureAtlas
         public PropertyBakeSetting BakeSetting = PropertyBakeSetting.NotBake;
         public AtlasShaderSupportUtils()
         {
+            Profiler.BeginSample("AtlasShaderSupportUtils");
             _defaultShaderSupport = new AtlasDefaultShaderSupport();
             _shaderSupports = InterfaceUtility.GetInterfaceInstance<IAtlasShaderSupport>(new Type[] { typeof(AtlasDefaultShaderSupport) }).ToList();
+            Profiler.EndSample();
         }
 
         public void AddRecord(Material material)
@@ -38,6 +41,8 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
         public List<PropAndTexture> GetTextures(Material material, ITextureManager textureManager)
         {
+            Profiler.BeginSample("GetTextures");
+            
             List<PropAndTexture> allTex;
             var supportShaderI = FindSupportI(material);
 
@@ -52,6 +57,8 @@ namespace net.rs64.TexTransTool.TextureAtlas
                     textures.Add(tex);
                 }
             }
+            
+            Profiler.EndSample();
 
             return textures;
         }

--- a/Runtime/TextureAtlas/AtlasTexture.cs
+++ b/Runtime/TextureAtlas/AtlasTexture.cs
@@ -10,6 +10,8 @@ using static net.rs64.TexTransCore.TransTextureCore.TransTexture;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
 using net.rs64.TexTransTool.TextureAtlas.FineTuning;
 using net.rs64.TexTransTool.TextureAtlas.IslandRelocator;
+using Unity.Profiling;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransTool.TextureAtlas
 {
@@ -129,7 +131,10 @@ namespace net.rs64.TexTransTool.TextureAtlas
             }).Where(I => I.Material != null && NowContainsMatSet.Contains(I.Material)).GroupBy(i => i.Material).Select(i => i.First()).ToList();
             atlasData.AtlasInMaterials = targetMaterialSelectors;
             var atlasSetting = AtlasSetting;
+            Profiler.BeginSample("AtlasReferenceData:ctor");
             var atlasReferenceData = new AtlasReferenceData(targetMaterialSelectors.Select(I => I.Material).ToList(), Renderers);
+            Profiler.EndSample();
+            
             var shaderSupports = new AtlasShaderSupportUtils();
 
             //サブメッシュより多いスロットの存在可否
@@ -149,9 +154,12 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
 
             //アイランドまわり
+            Profiler.BeginSample("AtlasReferenceData:GeneratedIslandPool");
             var originIslandPool = atlasReferenceData.GeneratedIslandPool();
+            Profiler.EndSample();
 
             //サブメッシュ間で頂点を共有するアイランドのマージ
+            Profiler.BeginSample("Cross-submesh island merging");
             var containsIdenticalIslandForMultipleSubMesh = false;
             for (var amdIndex = 0; atlasReferenceData.AtlasMeshDataList.Count > amdIndex; amdIndex += 1)
             {
@@ -199,11 +207,13 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
             }
             if (containsIdenticalIslandForMultipleSubMesh) { TTTRuntimeLog.Warning("AtlasTexture:error:IdenticalIslandForMultipleSubMesh"); }
+            Profiler.EndSample();
 
 
 
             if (atlasSetting.PixelNormalize)
             {
+                Profiler.BeginSample("AtlasReferenceData:PixelNormalize");
                 foreach (var islandKV in originIslandPool)
                 {
                     var material = materialTextures[atlasReferenceData.GetMaterialReference(islandKV.Key)];
@@ -213,6 +223,7 @@ namespace net.rs64.TexTransTool.TextureAtlas
                     island.Pivot.y = Mathf.Round(island.Pivot.y * refTex.height) / refTex.height;
                     island.Pivot.x = Mathf.Round(island.Pivot.x * refTex.width) / refTex.width;
                 }
+                Profiler.EndSample();
             }
 
             var islandSizeOffset = new Dictionary<Material, float>();
@@ -252,7 +263,9 @@ namespace net.rs64.TexTransTool.TextureAtlas
             relocator.UseUpScaling = atlasSetting.UseUpScaling;
             relocator.Padding = atlasSetting.IslandPadding;
 
+            Profiler.BeginSample("Relocation");
             islandRectPool = relocator.Relocation(islandRectPool, originIslandPool);
+            Profiler.EndSample();
             var rectTangleMove = relocator.RectTangleMove;
 
             if (atlasSetting.PixelNormalize)
@@ -277,6 +290,7 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
 
             //新しいUVを持つMeshを生成するフェーズ
+            Profiler.BeginSample("MeshCompile");
             var compiledMeshes = new List<AtlasData.AtlasMeshAndDist>();
             var poolContainsTags = ToIndexTags(islandRectPool.Keys);
             for (int I = 0; I < atlasReferenceData.AtlasMeshDataList.Count; I += 1)
@@ -284,8 +298,11 @@ namespace net.rs64.TexTransTool.TextureAtlas
                 var atlasMeshData = atlasReferenceData.AtlasMeshDataList[I];
 
                 var distMesh = atlasReferenceData.Meshes[atlasMeshData.ReferenceMesh];
+                var meshName = "AtlasMesh_" + I + "_" + distMesh.name;
+                
+                Profiler.BeginSample(meshName);
                 var newMesh = UnityEngine.Object.Instantiate<Mesh>(distMesh);
-                newMesh.name = "AtlasMesh_" + I + "_" + distMesh.name;
+                newMesh.name = meshName;
 
                 var meshTags = new List<AtlasIdenticalTag>();
 
@@ -328,21 +345,26 @@ namespace net.rs64.TexTransTool.TextureAtlas
                 if (AtlasSetting.WriteOriginalUV) { newMesh.SetUVs(1, atlasMeshData.UV); }
 
                 compiledMeshes.Add(new AtlasData.AtlasMeshAndDist(distMesh, newMesh, atlasMeshData.MaterialIndex.Select(Index => atlasReferenceData.Materials[Index]).ToArray()));
+                
+                Profiler.EndSample();
             }
             atlasData.Meshes = compiledMeshes;
+            Profiler.EndSample();
 
 
             //アトラス化したテクスチャーを生成するフェーズ
             var compiledAtlasTextures = new List<PropAndTexture2D>();
 
             var propertyNames = materialTextures.Values.SelectMany(i => i).Select(i => i.PropertyName).ToHashSet();
-
-
+            
+            Profiler.BeginSample("Texture synthesis");
             foreach (var propName in propertyNames)
             {
                 var targetRT = RenderTexture.GetTemporary(atlasSetting.AtlasTextureSize, atlasTextureHeightSize, 32);
                 targetRT.Clear();
                 targetRT.name = "AtlasTex" + propName;
+                Profiler.BeginSample("Draw:" + targetRT.name);
+                
                 foreach (var MatPropKV in materialTextures)
                 {
                     var souseProp2Tex = MatPropKV.Value.Find(I => I.PropertyName == propName);
@@ -382,9 +404,18 @@ namespace net.rs64.TexTransTool.TextureAtlas
                     if (souseProp2Tex.Texture is Texture2D && souseTex is RenderTexture tempRt) { RenderTexture.ReleaseTemporary(tempRt); }
                 }
 
+                Profiler.EndSample();
+                
+                Profiler.BeginSample("Readback");
+                
                 compiledAtlasTextures.Add(new PropAndTexture2D(propName, targetRT.CopyTexture2D()));
+                
+                Profiler.EndSample();
+                
                 RenderTexture.ReleaseTemporary(targetRT);
             }
+            Profiler.EndSample();
+            
             foreach (var matData in materialTextures)
             {
                 foreach (var pTex in matData.Value)
@@ -448,17 +479,21 @@ namespace net.rs64.TexTransTool.TextureAtlas
                 TTTRuntimeLog.Error("AtlasTexture:error:TTTNotExecutable");
                 return;
             }
-
+            
             domain.ProgressStateEnter("AtlasTexture");
             domain.ProgressUpdate("CompileAtlasTexture", 0f);
 
-            if (!TryCompileAtlasTextures(domain, out var atlasData)) { return; }
+            Profiler.BeginSample("TryCompileAtlasTextures");
+            if (!TryCompileAtlasTextures(domain, out var atlasData)) { Profiler.EndSample(); return; }
+            Profiler.EndSample();
 
             domain.ProgressUpdate("MeshChange", 0.5f);
 
             var nowRenderers = Renderers;
 
+            Profiler.BeginSample("AtlasShaderSupportUtils:ctor");
             var shaderSupport = new AtlasShaderSupportUtils();
+            Profiler.EndSample();
 
             //Mesh Change
             foreach (var renderer in nowRenderers)

--- a/Runtime/TextureAtlas/TextureFineTuning/MipMapRemove.cs
+++ b/Runtime/TextureAtlas/TextureFineTuning/MipMapRemove.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace net.rs64.TexTransTool.TextureAtlas.FineTuning
 {
@@ -54,12 +55,14 @@ namespace net.rs64.TexTransTool.TextureAtlas.FineTuning
                 if (mipMapData == null) { continue; }
                 if (mipMapData.UseMipMap == texf.Texture2D.mipmapCount > 1) { continue; }
 
+                Profiler.BeginSample("MipMapApplicant");
                 var newTex = new Texture2D(texf.Texture2D.width, texf.Texture2D.height, TextureFormat.RGBA32, mipMapData.UseMipMap, !texf.Texture2D.isDataSRGB);
                 var pixelData = texf.Texture2D.GetPixelData<Color32>(0);
                 newTex.SetPixelData(pixelData, 0); pixelData.Dispose();
                 newTex.Apply();
                 newTex.name = texf.Texture2D.name;
                 texf.Texture2D = newTex;
+                Profiler.EndSample();
             }
         }
     }

--- a/TexTransCore/TransTextureCore/AsyncTexture2D.cs
+++ b/TexTransCore/TransTextureCore/AsyncTexture2D.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Profiling;
+using UnityEngine.Rendering;
+
+namespace net.rs64.TexTransCore.TransTextureCore
+{
+    public class AsyncTexture2D
+    {
+        private string _name;
+        private RenderTexture _rt;
+        private AsyncGPUReadbackRequest[] _asyncGPUReadbackRequests;
+        private bool _mipsFromRT, _rawRead;
+        private Texture2D _outTex;
+
+        private static Queue<Action> _pendingActions = new Queue<Action>();
+
+        private TextureFormat _format;
+        private bool _useMip;
+
+        private void CreateTexIfNeeded()
+        {
+            if (_outTex == null)
+            {
+                Profiler.BeginSample("Construct Tex2D");
+                _outTex = new Texture2D(_rt.width, _rt.height, _format, _useMip, !_rt.sRGB);
+                _outTex.name = _name;
+                Profiler.EndSample();
+            }
+        }
+        
+        public AsyncTexture2D(RenderTexture rt, TextureFormat? overrideFormat = null, bool? overrideUseMip = null)
+        {
+            _name = rt.name + "_CopyTex2D"; 
+            
+            _useMip = overrideUseMip ?? rt.useMipMap;
+            _format = overrideFormat ?? GraphicsFormatUtility.GetTextureFormat(rt.graphicsFormat);
+            var readMapCount = rt.useMipMap && _useMip ? rt.mipmapCount : 1;
+
+            // Texture2Dの作成はかなり重いようなので、リードバックを開始してから行います。
+            // なお、GetPixelDataのバッファーをそのままAsyncGPUReadback.RequestIntoNativeArrayに渡すこともためしたけど、
+            // 最初のGetPixelDataで40ms以上かかってて使い物にならなかった・・・
+            _pendingActions.Enqueue(this.CreateTexIfNeeded);
+
+            int mipsRemaining = readMapCount;
+            _asyncGPUReadbackRequests = new AsyncGPUReadbackRequest[readMapCount];
+            for (var i = 0; readMapCount > i; i += 1)
+            {
+                var mipLevel = i;
+                
+                _asyncGPUReadbackRequests[i] = AsyncGPUReadback.Request(rt, i, _format, req =>
+                {
+                    Action _readTex = () =>
+                    {
+                        Profiler.BeginSample("Ingest texture");
+                        var buf = req.GetData<byte>();
+                        _outTex.SetPixelData(buf, mipLevel);
+                        buf.Dispose();
+                        Profiler.EndSample();
+                    };
+
+                    if (_outTex != null)
+                    {
+                        // すでにTexture2Dが作成されている場合は、そのままTexture2Dにデータを流し込みます。
+                        _readTex();
+                    }
+                    else
+                    {
+                        // WaitAllRequestsの後にデータを流し込みます
+                        _pendingActions.Enqueue(_readTex);
+                    }
+                });
+                
+            }
+
+            _mipsFromRT = _useMip;
+            _rt = rt;
+        }
+        
+        public Texture2D GetTexture2D()
+        {
+            Profiler.BeginSample("GetTexture2D");
+            
+            // たまったTexture2Dの作成処理を実行
+            Profiler.BeginSample("Process pending actions");
+            while (_pendingActions.Count > 0)
+            {
+                _pendingActions.Dequeue()();
+            }
+            Profiler.EndSample();
+            
+            Profiler.BeginSample("Await async readback");
+            AsyncGPUReadback.WaitAllRequests();
+            Profiler.EndSample();
+            
+            // Texture2Dの作成が間に合わなかったリードバックに関しては、ここでデータを流し込んでおきます。
+            Profiler.BeginSample("Process pending actions");
+            while (_pendingActions.Count > 0)
+            {
+                _pendingActions.Dequeue()();
+            }
+            Profiler.EndSample();
+            
+            Profiler.BeginSample("Apply texture");
+            _outTex.Apply(!_mipsFromRT);
+            Profiler.EndSample();
+            
+            RenderTexture.ReleaseTemporary(_rt);
+            
+            Profiler.EndSample();
+            return _outTex;
+        }
+    }
+}

--- a/TexTransCore/TransTextureCore/AsyncTexture2D.cs.meta
+++ b/TexTransCore/TransTextureCore/AsyncTexture2D.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 434ddc8e5efc4771acf504650bf68dab
+timeCreated: 1710652690

--- a/TexTransCore/TransTextureCore/Utils/TextureUtility.cs
+++ b/TexTransCore/TransTextureCore/Utils/TextureUtility.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using net.rs64.TexTransCore.BlendTexture;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
+using UnityEngine.Profiling;
 using UnityEngine.Rendering;
 
 namespace net.rs64.TexTransCore.TransTextureCore.Utils
@@ -66,6 +67,7 @@ namespace net.rs64.TexTransCore.TransTextureCore.Utils
 
         public static Texture2D ResizeTexture(Texture2D souse, Vector2Int size)
         {
+            Profiler.BeginSample("ResizeTexture");
             using (new RTActiveSaver())
             {
                 var useMip = souse.mipmapCount > 1;
@@ -96,6 +98,8 @@ namespace net.rs64.TexTransCore.TransTextureCore.Utils
                 resizedTexture.name = souse.name + "_Resized_" + size.x.ToString();
 
                 RenderTexture.ReleaseTemporary(rt);
+                Profiler.EndSample();
+                
                 return resizedTexture;
             }
         }


### PR DESCRIPTION
4k のAtlasTextureで約150msを節約できます（7950X3D, RTX 4090で計測）