### PR TITLE
Fix un normalized uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - UVtoIsland の高速化 (#412)
+- Materialの使い回しにより TransTexture と TextureBend が若干の高速化 (#430)
 
 ### Changed
 
@@ -18,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UVtoIsland の高速化 に伴い UseIslandCash は削除されました (#412)
 
 ### Fixed
+
+- 0~1 範囲外のUVを持つメッシュに SimpleDecal が正しく使用できない問題を修正 (#430)
+- 0~1 範囲外のUVを持つメッシュにデカールのリアルタイムプレビューを使用した時真っ黒になる問題を修正 (#430)
+- SimpleDecal のリアルタイムプレビューが不必要にレンダーテクスチャの更新を重複して行っていた問題を修正 (#430)
 
 ### Deprecated
 

--- a/Editor/Utils/LateInitializeUtility.cs
+++ b/Editor/Utils/LateInitializeUtility.cs
@@ -20,10 +20,12 @@ namespace net.rs64.TexTransTool.Utils
         {
             TTTConfig.SettingInitializer();
             Localize.LocalizeInitializer();
-            TextureBlend.BlendShadersInit();
             PSDImportedRasterImage.MargeColorAndOffsetShader = Shader.Find(PSDImportedRasterImage.MARGE_COLOR_AND_OFFSET_SHADER);
             SpecialLayerShaders.Init();
             TTTImageAssets.Init();
+            TexTransCore.TexTransCoreRuntime.Initialize();
+            UnityEditor.EditorApplication.update += TexTransCore.TexTransCoreRuntime.Update.Invoke;
+            UnityEditor.EditorApplication.delayCall += TexTransCore.TexTransCoreRuntime.DelayUpdate.Invoke;
         }
     }
 }

--- a/Runtime/ReferenceResolver/Decal/AbstractRayCastRendererResolver.cs
+++ b/Runtime/ReferenceResolver/Decal/AbstractRayCastRendererResolver.cs
@@ -3,8 +3,8 @@ using net.rs64.TexTransCore.Island;
 using net.rs64.TexTransTool.Decal;
 using UnityEngine;
 using net.rs64.TexTransCore.Decal;
-using net.rs64.TexTransCore.TransTextureCore;
 using net.rs64.TexTransCore.TransTextureCore.Utils;
+using net.rs64.TexTransCore;
 
 namespace net.rs64.TexTransTool.ReferenceResolver.ATResolver
 {

--- a/TexTransCore/Memoize.cs
+++ b/TexTransCore/Memoize.cs
@@ -3,31 +3,26 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEditor;
 
-namespace net.rs64.TexTransCore.TransTextureCore
+namespace net.rs64.TexTransCore
 {
     internal static class FrameMemoEvents
     {
-#pragma warning disable CS0067 // Event is never used
         internal static event Action OnClearMemo;
-#pragma warning restore CS0067 // Event is never used
 
-#if UNITY_EDITOR
-        [InitializeOnLoadMethod]
-        static void Init()
+        internal static void Init()
         {
-            EditorApplication.update += () =>
+            TexTransCoreRuntime.Update += () =>
             {
                 OnClearMemo?.Invoke();
                 OnClearMemo = default;
             };
         }
-#endif
     }
 
     public static class Memoize
     {
         private static Dictionary<(object, object), (object, Action)> MemoData = new();
-        
+
         /// <summary>
         /// 変換関数の結果を一フレームだけ記憶するヘルパーです。同じoriginalとtransformを再度渡せば、計算結果を使いまわします。
         /// </summary>
@@ -58,7 +53,7 @@ namespace net.rs64.TexTransCore.TransTextureCore
                         MemoData.Clear();
                     };
                 }
-                
+
                 var output = transform(original);
                 MemoData[memoKey] = (output, () => destroy?.Invoke(output));
                 return output;

--- a/TexTransCore/TexTransCoreRuntime.cs
+++ b/TexTransCore/TexTransCoreRuntime.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using net.rs64.TexTransCore.BlendTexture;
+using UnityEditor;
+
+namespace net.rs64.TexTransCore
+{
+    public static class TexTransCoreRuntime
+    {
+        public static void Initialize()//シェーダー等がロードさている状態を想定している。
+        {
+            TextureBlend.BlendShadersInit();
+            FrameMemoEvents.Init();
+        }
+        public static Action Update = () =>{};
+        public static Action DelayUpdate = () =>{};
+        public static Func<string,UnityEngine.Object> LoadAsset;
+
+    }
+}

--- a/TexTransCore/TexTransCoreRuntime.cs.meta
+++ b/TexTransCore/TexTransCoreRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5488dec9f70b9b44a11db43d99425d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TexTransCore/TransTextureCore/ShaderAsset/TransTextureHelper.hlsl
+++ b/TexTransCore/TransTextureCore/ShaderAsset/TransTextureHelper.hlsl
@@ -28,31 +28,61 @@
             float _WarpRangeX;
             float _WarpRangeY;
 
-
-            v2f vert (appdata v)
+            v2f MappedScreenSpace(v2f o)
             {
-                v2f o;
-                o.vertex = v.vertex;
                 o.vertex.x *= 2;
                 o.vertex.y *= 2;
                 o.vertex.x -=1;
                 o.vertex.y -=1;
                 o.vertex.z = 1;
-
-                o.normal = v.normal;
 #if UNITY_UV_STARTS_AT_TOP
                 o.vertex.y = -1 * o.vertex.y;
-                o.normal.y = -1 * v.normal.y;
+                o.normal.y = -1 * o.normal.y;
 #endif
-                o.uv = v.uv;
                 return o;
             }
 
-            v2f PaddingCal(v2f center , v2f input,float Padding)
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = v.vertex;
+                o.normal = v.normal;
+                o.uv = v.uv;
+
+#if NotGeometry
+                return MappedScreenSpace(o);
+#else
+                return o;
+#endif
+            }
+
+
+            v2f GetV2f()
+            {
+                v2f defVal;
+
+                float val = 0;
+
+                #if NotDepth
+                defVal.uv = val.xx;
+                #else
+                defVal.uv = val.xxx;
+                #endif
+
+                defVal.normal = val.xxx;
+                defVal.vertex = val.xxxx;
+
+                return defVal;
+            }
+
+            v2f PaddingCal(v2f center , v2f input , float Padding)
             {
                 float PixelStep = (1 / length(_ScreenParams.xy));
                 float LerpPixelStep  = length(input.vertex - center.vertex) / PixelStep;
-                float PaddingValue =  (Padding / LerpPixelStep) * -1;
+                #if NotDepth
+                LerpPixelStep += 0.00000000000000000000000000001;
+                #endif
+                float PaddingValue =  (Padding / (LerpPixelStep)) * -1;
                 v2f o;
                 o.uv = lerp(input.uv ,center.uv ,PaddingValue);
 
@@ -67,15 +97,70 @@
                 o.normal = input.normal;
                 return o;
             }
-            float2 ReCalUV(triangle v2f input[3], v2f Target)
+            void MappedScreenSpaceTriangel(inout v2f tri[3])
             {
-              float4 CrossT = CrossTriangle(input[0].vertex , input[1].vertex , input[2].vertex , Target.vertex);
-              float2 recalUV = FromBarycentricCoordinateSystem(input[0].uv.xyy , input[1].uv.xyy , input[2].uv.xyy , ToBarycentricCoordinateSystem(CrossT)).xy;
+                [unroll]
+                for(int i = 0; 3 > i; i += 1)
+                {
+                    tri[i] = MappedScreenSpace(tri[i]);
+                }
+
+            }
+            float2 ReCalUV(in v2f input[3], v2f Target)
+            {
+              float4 CrossT = CrossTriangle(input[0].vertex.xyz , input[1].vertex.xyz , input[2].vertex.xyz , Target.vertex.xyz);
+              float2 recalUV = FromBarycentricCoordinateSystem(input[0].uv.xy , input[1].uv.xy , input[2].uv.xy , ToBarycentricCoordinateSystem(CrossT)).xy;
               recalUV = isnan(recalUV) ? Target.uv : recalUV;
               return recalUV;
             }
-            [maxvertexcount(18)]
-            void geom (triangle v2f input[3], inout TriangleStream<v2f> stream)
+            void WriteStream(in v2f Origin[3],in v2f Padding[3],inout TriangleStream<v2f> stream)
+            {
+                stream.Append(Padding[0]);
+                stream.Append(Origin[0]);
+                stream.Append(Padding[1]);
+                stream.RestartStrip();
+
+                stream.Append(Origin[0]);
+                stream.Append(Origin[1]);
+                stream.Append(Padding[1]);
+                stream.RestartStrip();
+
+                stream.Append(Origin[1]);
+                stream.Append(Padding[1]);
+                stream.Append(Padding[2]);
+                stream.RestartStrip();
+
+                stream.Append(Origin[1]);
+                stream.Append(Origin[2]);
+                stream.Append(Padding[2]);
+                stream.RestartStrip();
+
+                stream.Append(Origin[2]);
+                stream.Append(Padding[0]);
+                stream.Append(Padding[2]);
+                stream.RestartStrip();
+
+                stream.Append(Origin[0]);
+                stream.Append(Padding[0]);
+                stream.Append(Origin[2]);
+                stream.RestartStrip();
+            }
+            void tileNormalize(in v2f input[3],out v2f outPut[3])
+            {
+                float2 minPos = min(input[0].vertex.xy,min(input[1].vertex.xy,input[2].vertex.xy));
+                float2 tile = floor(minPos);
+
+                float2 normalizedMinPos = minPos - tile;
+
+
+                [unroll]
+                for(int i = 0; 3 > i; i += 1)
+                {
+                    outPut[i] = input[i];
+                    outPut[i].vertex.xy = normalizedMinPos + (input[i].vertex.xy - minPos);
+                }
+            }
+            void paddingCali(in v2f input[3],out v2f outPut[3])
             {
                 v2f center;
                 center.uv = lerp(lerp(input[0].uv ,input[1].uv ,0.5) ,input[2].uv ,0.5);
@@ -96,35 +181,45 @@
                 g2.uv = input[2].uv;
 #endif
 
-                stream.Append(g0);
-                stream.Append(input[0]);
-                stream.Append(g1);
-                stream.RestartStrip();
+                outPut[0] = g0;
+                outPut[1] = g1;
+                outPut[2] = g2;
+            }
 
-                stream.Append(input[0]);
-                stream.Append(input[1]);
-                stream.Append(g1);
-                stream.RestartStrip();
+            [maxvertexcount(3)]
+            void geom (triangle v2f input[3], inout TriangleStream<v2f> stream)
+            {
+                v2f Origin[3] = {input[0],input[1],input[2]};
 
-                stream.Append(input[1]);
-                stream.Append(g1);
-                stream.Append(g2);
-                stream.RestartStrip();
+#if !UnTileNormalize
+                v2f tileNormalized[3] = {GetV2f(),GetV2f(),GetV2f()};
+                tileNormalize(Origin , tileNormalized);
+                Origin = tileNormalized;
+#endif
+                MappedScreenSpaceTriangel(Origin);
 
-                stream.Append(input[1]);
-                stream.Append(input[2]);
-                stream.Append(g2);
+                stream.Append(Origin[0]);
+                stream.Append(Origin[1]);
+                stream.Append(Origin[2]);
                 stream.RestartStrip();
+            }
 
-                stream.Append(input[2]);
-                stream.Append(g0);
-                stream.Append(g2);
-                stream.RestartStrip();
+            [maxvertexcount(18)]
+            void puddingGeom (triangle v2f input[3], inout TriangleStream<v2f> stream)
+            {
+                v2f Origin[3] = {input[0],input[1],input[2]};
 
-                stream.Append(input[0]);
-                stream.Append(g0);
-                stream.Append(input[2]);
-                stream.RestartStrip();
+#if !UnTileNormalize
+                v2f tileNormalized[3] = {GetV2f(),GetV2f(),GetV2f()};
+                tileNormalize(Origin , tileNormalized);
+                Origin = tileNormalized;
+#endif
+                MappedScreenSpaceTriangel(Origin);
+
+                v2f paddingV[3] = {GetV2f(),GetV2f(),GetV2f()};
+                paddingCali(Origin , paddingV);
+
+                WriteStream(Origin , paddingV , stream);
             }
 
 
@@ -139,6 +234,7 @@
                 Rangeflag  = 0.5 - Rangeflag;
                 clip(Rangeflag);
 #endif
+
 #if DepthDecal
                 float DepthValue = tex2Dlod(_DepthTex ,float4(i.uv.xy,0,0)).r;
                 clip( ((1.0001 - i.uv.z) < DepthValue ) * -1 + 0.5);

--- a/TexTransCore/TransTextureCore/ShaderAsset/TransTextureShader.shader
+++ b/TexTransCore/TransTextureCore/ShaderAsset/TransTextureShader.shader
@@ -26,8 +26,10 @@ Shader "Hidden/TransTexture"
             HLSLPROGRAM
             #pragma exclude_renderers metal
             #pragma vertex vert
+            #pragma geometry geom
             #pragma fragment frag
             #pragma shader_feature_local_fragment WarpRange
+            #pragma shader_feature_local_geometry UnTileNormalize
             #pragma multi_compile_local NotDepth DepthDecal InvertDepth
 
             #include "./TransTextureHelper.hlsl"
@@ -45,10 +47,11 @@ Shader "Hidden/TransTexture"
             HLSLPROGRAM
             #pragma exclude_renderers metal
             #pragma vertex vert
-            #pragma geometry geom
+            #pragma geometry puddingGeom
             #pragma fragment frag
             #pragma shader_feature_local_fragment WarpRange
             #pragma shader_feature_local HighQualityPadding
+            #pragma shader_feature_local_geometry UnTileNormalize
             #pragma multi_compile_local NotDepth DepthDecal InvertDepth
 
 
@@ -78,7 +81,9 @@ Shader "Hidden/TransTexture"
             #pragma shader_feature_local_fragment WarpRange
             #pragma multi_compile_local NotDepth DepthDecal InvertDepth
 
+            #define NotGeometry 1
             #include "./TransTextureHelper.hlsl"
+            #undef NotGeometry
 
             ENDHLSL
         }

--- a/TexTransCore/TransTextureCore/ShaderAsset/TransTextureShader.shader.meta
+++ b/TexTransCore/TransTextureCore/ShaderAsset/TransTextureShader.shader.meta
@@ -2,7 +2,9 @@ fileFormatVersion: 2
 guid: 34ef1d322f9edd84eabe17e7ba43bd38
 ShaderImporter:
   externalObjects: {}
-  defaultTextures: []
+  defaultTextures:
+  - _MainTex: {instanceID: 0}
+  - _DepthTex: {instanceID: 0}
   nonModifiableTextures: []
   userData: 
   assetBundleName: 

--- a/TexTransCore/TransTextureCore/TransTexture.cs
+++ b/TexTransCore/TransTextureCore/TransTexture.cs
@@ -13,6 +13,7 @@ using Unity.Jobs;
 using UnityEditor;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
+using System;
 
 namespace net.rs64.TexTransCore.TransTextureCore
 {
@@ -23,7 +24,7 @@ namespace net.rs64.TexTransCore.TransTextureCore
             public NativeArray<TriangleIndex> TrianglesToIndex;
             public NativeArray<Vector2> TargetUV;
             public NativeArray<UVDimension> SourceUV;
-            
+
             public TransData(
                 IEnumerable<TriangleIndex> trianglesToIndex,
                 IEnumerable<Vector2> targetUV,
@@ -36,16 +37,14 @@ namespace net.rs64.TexTransCore.TransTextureCore
                 SourceUV = new NativeArray<UVDimension>(sourceUV.ToArray(), Allocator.TempJob);
 
                 var self = this;
-                #if UNITY_EDITOR
-                EditorApplication.delayCall += () =>
+                TexTransCoreRuntime.DelayUpdate += () =>
                 {
                     self.TrianglesToIndex.Dispose();
                     self.TargetUV.Dispose();
                     self.SourceUV.Dispose();
                 };
-                #endif
             }
-            
+
             public TransData(NativeArray<TriangleIndex> trianglesToIndex, NativeArray<Vector2> targetUV, NativeArray<UVDimension> sourceUV)
             {
                 TrianglesToIndex = trianglesToIndex;
@@ -57,7 +56,7 @@ namespace net.rs64.TexTransCore.TransTextureCore
             {
                 var mda = Mesh.AllocateWritableMeshData(1);
                 var mda_mesh = mda[0];
-                
+
                 mda_mesh.SetVertexBufferParams(
                     TargetUV.Length,
                     new VertexAttributeDescriptor(VertexAttribute.Position, VertexAttributeFormat.Float32, 3),
@@ -68,18 +67,18 @@ namespace net.rs64.TexTransCore.TransTextureCore
                 var pos_array = mda_mesh.GetVertexData<Vector3>(0);
                 var uv_array = mda_mesh.GetVertexData<UVDimension>(1);
                 var dst_triangles = mda_mesh.GetIndexData<int>();
-                
+
                 var job1 = new CopyPos { Source = TargetUV, Destination = pos_array }.Schedule(TargetUV.Length, 64);
                 var job2 = new CopyJob<UVDimension> { Source = SourceUV, Destination = uv_array }.Schedule(SourceUV.Length, 64, job1);
                 var job3 = new UnpackTriangleJob { Source = TrianglesToIndex, Destination = dst_triangles }.Schedule(dst_triangles.Length, 64, job2);
 
                 var mesh = new Mesh();
-                
+
                 job3.Complete();
 
                 mda_mesh.subMeshCount = 1;
                 mda_mesh.SetSubMesh(0, new SubMeshDescriptor(0, dst_triangles.Length, MeshTopology.Triangles));
-                
+
                 Mesh.ApplyAndDisposeWritableMeshData(mda, mesh);
 
                 return mesh;
@@ -93,18 +92,18 @@ namespace net.rs64.TexTransCore.TransTextureCore
             new CopyJob<Vector3>().Schedule(1, 1);
             new CopyJob<Vector4>().Schedule(1, 1);
         }
-        
+
         [BurstCompile]
         struct UnpackTriangleJob : IJobParallelFor
         {
             [ReadOnly] public NativeArray<TriangleIndex> Source;
             [WriteOnly] public NativeArray<int> Destination;
-                
+
             public void Execute(int index)
             {
                 var tri_index = index / 3;
                 var coord = index % 3;
-                    
+
                 Destination[index] = Source[tri_index][coord];
             }
         }
@@ -114,19 +113,19 @@ namespace net.rs64.TexTransCore.TransTextureCore
         {
             [ReadOnly] public NativeArray<Vector2> Source;
             [WriteOnly] public NativeArray<Vector3> Destination;
-                
+
             public void Execute(int index)
             {
                 Destination[index] = Source[index];
             }
         }
-            
+
         [BurstCompile]
         struct CopyJob<T> : IJobParallelFor where T : struct
         {
             [ReadOnly] public NativeArray<T> Source;
             [WriteOnly] public NativeArray<T> Destination;
-                
+
             public void Execute(int index)
             {
                 Destination[index] = Source[index];
@@ -135,6 +134,8 @@ namespace net.rs64.TexTransCore.TransTextureCore
 
         public const string TRANS_SHADER = "Hidden/TransTexture";
         public const string DEPTH_WRITER_SHADER = "Hidden/DepthWriter";
+
+        static Material s_TransMat;
         public static void ForTrans<UVDimension>(
             RenderTexture targetTexture,
             Texture souseTexture,
@@ -161,20 +162,21 @@ namespace net.rs64.TexTransCore.TransTextureCore
 
 
             Profiler.BeginSample("Material Setup");
-            var material = new Material(Shader.Find(TRANS_SHADER));
-            material.SetTexture("_MainTex", souseTexture);
-            if (padding.HasValue) material.SetFloat("_Padding", padding.Value);
+            if (s_TransMat == null) { s_TransMat = new Material(Shader.Find(TRANS_SHADER)); }
+            s_TransMat.shaderKeywords = Array.Empty<string>();
+            s_TransMat.SetTexture("_MainTex", souseTexture);
+            if (padding.HasValue) s_TransMat.SetFloat("_Padding", padding.Value);
             if (padding.HasValue && highQualityPadding)
             {
                 mesh.TTNormalCal();
-                material.EnableKeyword("HighQualityPadding");
+                s_TransMat.EnableKeyword("HighQualityPadding");
             }
 
             if (texWrap.WarpRange != null)
             {
-                material.EnableKeyword("WarpRange");
-                material.SetFloat("_WarpRangeX", texWrap.WarpRange.Value.x);
-                material.SetFloat("_WarpRangeY", texWrap.WarpRange.Value.y);
+                s_TransMat.EnableKeyword("WarpRange");
+                s_TransMat.SetFloat("_WarpRangeX", texWrap.WarpRange.Value.x);
+                s_TransMat.SetFloat("_WarpRangeY", texWrap.WarpRange.Value.y);
             }
             Profiler.EndSample();
 
@@ -184,7 +186,7 @@ namespace net.rs64.TexTransCore.TransTextureCore
             {
                 depthRt = RenderTexture.GetTemporary(targetTexture.width, targetTexture.height, 8, RenderTextureFormat.RFloat);
                 depthRt.Clear();
-                material.EnableKeyword(depthInvert.Value ? "InvertDepth" : "DepthDecal");
+                s_TransMat.EnableKeyword(depthInvert.Value ? "InvertDepth" : "DepthDecal");
 
                 using (new RTActiveSaver())
                 {
@@ -199,11 +201,11 @@ namespace net.rs64.TexTransCore.TransTextureCore
                     UnityEngine.Object.DestroyImmediate(depthMat);
                 }
 
-                material.SetTexture("_DepthTex", depthRt);
+                s_TransMat.SetTexture("_DepthTex", depthRt);
             }
             else
             {
-                material.EnableKeyword("NotDepth");
+                s_TransMat.EnableKeyword("NotDepth");
             }
 
 
@@ -213,13 +215,13 @@ namespace net.rs64.TexTransCore.TransTextureCore
             {
                 RenderTexture.active = targetTexture;
                 Profiler.BeginSample("DrawMeshNow");
-                material.SetPass(0);
+                s_TransMat.SetPass(0);
                 Graphics.DrawMeshNow(mesh, Matrix4x4.identity);
                 Profiler.EndSample();
                 if (padding != null)
                 {
                     Profiler.BeginSample("DrawMeshNow - padding");
-                    material.SetPass(1);
+                    s_TransMat.SetPass(1);
                     Graphics.DrawMeshNow(mesh, Matrix4x4.identity);
                     Profiler.EndSample();
                 }


### PR DESCRIPTION
simple decal のリアルタイムプレビューの時のワープモードのコピーや、タイル外にも行えるようにするなど、
あとマテリアルの使いまわしとリアルタイムプレビューのレンダーテクスチャのアップデートが不要に複数回呼ばれていたのを修正