### PR TITLE
refactor: remove GetDependency and GetDependencyHash

### DIFF
--- a/Editor/Preview/RealTime/RealTimePreviewContext.cs
+++ b/Editor/Preview/RealTime/RealTimePreviewContext.cs
@@ -9,6 +9,7 @@ using net.rs64.TexTransTool.Utils;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.Profiling;
 using UnityEngine.SceneManagement;
 
 namespace net.rs64.TexTransTool.Preview.RealTime
@@ -18,7 +19,6 @@ namespace net.rs64.TexTransTool.Preview.RealTime
         RealTimePreviewDomain _previewDomain = null;
         Dictionary<TexTransRuntimeBehavior, int> _PriorityMap = new();
         Dictionary<int, HashSet<TexTransRuntimeBehavior>> _dependencyMap = new();
-        Dictionary<TexTransRuntimeBehavior, int> _dependencyHashMap = new();
         HashSetQueue<TexTransRuntimeBehavior> _updateQueue = new();
 
 
@@ -45,7 +45,7 @@ namespace net.rs64.TexTransTool.Preview.RealTime
             AnimationMode.StartAnimationMode();
             AnimationMode.BeginSampling();
 
-            _previewDomain = new RealTimePreviewDomain(previewRoot);
+            _previewDomain = new RealTimePreviewDomain(previewRoot, RegisterDependency);
 
             var texTransBehaviors = AvatarBuildUtils.PhaseDictFlatten(AvatarBuildUtils.FindAtPhase(previewRoot));
             var priority = 0;
@@ -57,6 +57,11 @@ namespace net.rs64.TexTransTool.Preview.RealTime
             EditorApplication.update += UpdatePreview;
 
             foreach (var ttb in texTransBehaviors) { AddPreviewBehavior(ttb as TexTransRuntimeBehavior); }
+        }
+        void RegisterDependency(TexTransRuntimeBehavior texTransRuntimeBehavior, int dependInstanceID)
+        {
+            if (!_dependencyMap.ContainsKey(dependInstanceID)) { _dependencyMap[dependInstanceID] = new(); }
+            _dependencyMap[dependInstanceID].Add(texTransRuntimeBehavior);
         }
 
         void AddPreviewBehavior(TexTransRuntimeBehavior texTransRuntimeBehavior)
@@ -71,23 +76,7 @@ namespace net.rs64.TexTransTool.Preview.RealTime
             }
             if (ContainsBehavior(texTransRuntimeBehavior)) { return; }
 
-            RegisterDependency(texTransRuntimeBehavior);
             _updateQueue.Enqueue(texTransRuntimeBehavior);
-        }
-
-        private void RegisterDependency(TexTransRuntimeBehavior texTransRuntimeBehavior)
-        {
-            _dependencyHashMap[texTransRuntimeBehavior] = texTransRuntimeBehavior.GetDependencyHash(_previewDomain);
-            foreach (var dependInstanceID in texTransRuntimeBehavior.GetDependency(_previewDomain)
-                                                                    .Append(texTransRuntimeBehavior)
-                                                                    .Append(texTransRuntimeBehavior.gameObject)
-                                                                    .Concat(texTransRuntimeBehavior.gameObject.GetParents())
-                                                                    .Where(g => g != null).Select(g => g.GetInstanceID())
-                                                                    )
-            {
-                if (!_dependencyMap.ContainsKey(dependInstanceID)) { _dependencyMap[dependInstanceID] = new(); }
-                _dependencyMap[dependInstanceID].Add(texTransRuntimeBehavior);
-            }
         }
 
         void UnRegisterDependency(TexTransRuntimeBehavior texTransRuntimeBehavior) { foreach (var depend in _dependencyMap) { depend.Value.Remove(texTransRuntimeBehavior); } }
@@ -149,21 +138,24 @@ namespace net.rs64.TexTransTool.Preview.RealTime
 
         void UpdatePreview()
         {
+            Profiler.BeginSample("UpdatePreview");
             if (_updateQueue.TryDequeue(out var texTransRuntimeBehavior) && _PriorityMap.TryGetValue(texTransRuntimeBehavior, out var priority))
             {
-                if (_dependencyHashMap[texTransRuntimeBehavior] != texTransRuntimeBehavior.GetDependencyHash(_previewDomain))
-                {
-                    UnRegisterDependency(texTransRuntimeBehavior);
-                    RegisterDependency(texTransRuntimeBehavior);
-                }
+                Profiler.BeginSample("UnRegisterDependency");
+                UnRegisterDependency(texTransRuntimeBehavior);
+                Profiler.EndSample();
 
-                _previewDomain.SetNowPriority(priority);
-
+                Profiler.BeginSample("Apply");
+                _previewDomain.SetNowBehavior(texTransRuntimeBehavior, priority);
                 try { if (texTransRuntimeBehavior.gameObject.activeInHierarchy && texTransRuntimeBehavior.IsPossibleApply) { texTransRuntimeBehavior.Apply(_previewDomain); } }
                 catch (Exception ex) { Debug.LogException(ex); }
+                Profiler.EndSample();
 
+                Profiler.BeginSample("NeededStackUpdate");
                 _previewDomain.UpdateNeeded();
+                Profiler.EndSample();
             }
+            Profiler.EndSample();
         }
 
 

--- a/Editor/Preview/RealTime/RealTimePreviewDomain.cs
+++ b/Editor/Preview/RealTime/RealTimePreviewDomain.cs
@@ -13,9 +13,12 @@ namespace net.rs64.TexTransTool.Preview.RealTime
         ITextureManager _textureManager = new TextureManager(true);
         PreviewStackManager _stackManager = new();
         Dictionary<Material, Material> _previewMaterialMap = new();
-        public RealTimePreviewDomain(GameObject domainRoot)
+        Action<TexTransRuntimeBehavior, int> _lookAtCallBack;
+
+        public RealTimePreviewDomain(GameObject domainRoot, Action<TexTransRuntimeBehavior, int> lookAtCallBack)
         {
             _domainRoot = domainRoot;
+            _lookAtCallBack = lookAtCallBack;
             _stackManager.NewPreviewTexture += NewPreviewTextureRegister;
 
             _domainRenderers.Clear();
@@ -25,10 +28,12 @@ namespace net.rs64.TexTransTool.Preview.RealTime
 
         public GameObject DomainRoot => _domainRoot;
         int _nowPriority;
+        TexTransRuntimeBehavior _texTransRuntimeBehavior;
 
-        public void SetNowPriority(int priority)
+        public void SetNowBehavior(TexTransRuntimeBehavior texTransRuntimeBehavior, int priority)
         {
             _nowPriority = priority;
+            _texTransRuntimeBehavior = texTransRuntimeBehavior;
             _stackManager.ReleaseStackOfPriority(_nowPriority);
         }
 
@@ -138,5 +143,6 @@ namespace net.rs64.TexTransTool.Preview.RealTime
         public void ReplaceMaterials(Dictionary<Material, Material> mapping, bool one2one = true) { throw new NotImplementedException(); }
         public void SetMesh(Renderer renderer, Mesh mesh) { throw new NotImplementedException(); }
         public void TransferAsset(UnityEngine.Object asset) { throw new NotImplementedException(); }
+        public void LookAt(UnityEngine.Object obj) { _lookAtCallBack(_texTransRuntimeBehavior, obj.GetInstanceID()); }
     }
 }

--- a/Runtime/Common/TextureSelector.cs
+++ b/Runtime/Common/TextureSelector.cs
@@ -67,55 +67,6 @@ namespace net.rs64.TexTransTool
             }
             return domainRenderers.Where(i => i.sharedMaterials.Any(targetMatHash.Contains));
         }
-
-        internal IEnumerable<UnityEngine.Object> GetDependency()
-        {
-            switch (Mode)
-            {
-                default: yield break;
-                case SelectMode.Absolute: yield return SelectTexture; yield break;
-                case SelectMode.Relative:
-                    {
-                        yield return RendererAsPath;
-
-                        var DistMaterials = RendererAsPath.sharedMaterials;
-                        if (DistMaterials.Length <= SlotAsPath) { yield return DistMaterials[SlotAsPath]; }
-
-                        yield return GetTexture();
-                        yield break;
-                    }
-            }
-        }
-        internal int GetDependencyHash()
-        {
-            var hash = 0;
-            hash ^= (int)Mode;
-            switch (Mode)
-            {
-
-                case SelectMode.Absolute:
-                    {
-                        hash ^= SelectTexture?.GetInstanceID() ?? 0;
-                        break;
-                    }
-                case SelectMode.Relative:
-                    {
-                        if (RendererAsPath == null) { break; }
-                        hash ^= RendererAsPath?.GetInstanceID() ?? 0;
-                        var DistMaterials = RendererAsPath.sharedMaterials;
-                        if (DistMaterials.Length <= SlotAsPath) { break; }
-                        hash ^= SlotAsPath;
-                        hash ^= DistMaterials[SlotAsPath]?.GetInstanceID() ?? 0;
-
-                        hash ^= GetTexture()?.GetInstanceID() ?? 0;
-                        break;
-                    }
-            }
-
-            return hash;
-        }
-
-
-
+        internal void LookAtCalling(ILookingObject lookingObject) { lookingObject.LookAt(GetTexture()); }
     }
 }

--- a/Runtime/CommonComponent/MaterialOverrideTransfer.cs
+++ b/Runtime/CommonComponent/MaterialOverrideTransfer.cs
@@ -20,18 +20,5 @@ namespace net.rs64.TexTransTool
 
         public Material TargetMaterial;
         public Material MaterialVariantSource;
-
-        internal IEnumerable<Object> GetDependency(IDomain domain)
-        {
-            yield return TargetMaterial;
-            yield return MaterialVariantSource;
-        }
-
-        internal int GetDependencyHash(IDomain domain)
-        {
-            var hash = TargetMaterial?.GetInstanceID() ?? 0;
-            hash ^= MaterialVariantSource?.GetInstanceID() ?? 0;
-            return hash;
-        }
     }
 }

--- a/Runtime/CommonComponent/TextureBlender.cs
+++ b/Runtime/CommonComponent/TextureBlender.cs
@@ -26,10 +26,13 @@ namespace net.rs64.TexTransTool
 
         internal override void Apply(IDomain domain)
         {
+            domain.LookAt(this);
             if (!IsPossibleApply) { throw new TTTNotExecutable(); }
 
             var distTex = TargetTexture.GetTexture();
             if (distTex == null) { return; }
+
+            domain.LookAt(distTex);
 
             var addTex = TextureBlend.CreateMultipliedRenderTexture(BlendTexture, Color);
             domain.AddTextureStack<TextureBlend.BlendTexturePair>(distTex, new(addTex, BlendTypeKey));

--- a/Runtime/CommonComponent/TextureBlender.cs
+++ b/Runtime/CommonComponent/TextureBlender.cs
@@ -35,13 +35,6 @@ namespace net.rs64.TexTransTool
             domain.AddTextureStack<TextureBlend.BlendTexturePair>(distTex, new(addTex, BlendTypeKey));
         }
 
-        internal override IEnumerable<UnityEngine.Object> GetDependency(IDomain domain) { return TargetTexture.GetDependency().Append(BlendTexture); }
-
-        internal override int GetDependencyHash(IDomain domain)
-        {
-            return TargetTexture.GetDependencyHash() ^ BlendTexture?.GetInstanceID() ?? 0;
-        }
-
         internal override IEnumerable<Renderer> ModificationTargetRenderers(IEnumerable<Renderer> domainRenderers, OriginEqual replaceTracking)
         {
             return TargetTexture.ModificationTargetRenderers(domainRenderers);

--- a/Runtime/CommonComponent/TextureConfigurator.cs
+++ b/Runtime/CommonComponent/TextureConfigurator.cs
@@ -33,6 +33,7 @@ namespace net.rs64.TexTransTool
 
         internal override void Apply([NotNull] IDomain domain)
         {
+            domain.LookAt(this);
             if (!OverrideTextureSetting && !OverrideCompression) { return; }
 
             var textureManager = domain.GetTextureManager();
@@ -44,6 +45,8 @@ namespace net.rs64.TexTransTool
             .FirstOrDefault(i => domain.OriginEqual(i, target));
 
             if (targetTex2D == null) { TTTRuntimeLog.Info("TextureConfigurator:error:TargetNotFound"); return;}
+
+            domain.LookAt(targetTex2D);
 
             var newTexture2D = default(Texture2D);
             if (OverrideTextureSetting)

--- a/Runtime/CommonComponent/TextureConfigurator.cs
+++ b/Runtime/CommonComponent/TextureConfigurator.cs
@@ -19,9 +19,6 @@ namespace net.rs64.TexTransTool
 
         internal override bool IsPossibleApply => TargetTexture.GetTexture() != null;
         internal override TexTransPhase PhaseDefine => TexTransPhase.Optimizing;
-        internal override IEnumerable<UnityEngine.Object> GetDependency(IDomain domain) { return TargetTexture.GetDependency(); }
-        internal override int GetDependencyHash(IDomain domain) { return TargetTexture.GetDependencyHash(); }
-
 
         public TextureSelector TargetTexture;
 

--- a/Runtime/Decal/Gradation/SingleGradationDecal.cs
+++ b/Runtime/Decal/Gradation/SingleGradationDecal.cs
@@ -35,9 +35,10 @@ namespace net.rs64.TexTransTool.Decal
 
         internal override void Apply([NotNull] IDomain domain)
         {
+            domain.LookAt(this);
             domain.LookAt(transform.GetParents().Append(transform));
             if (IslandSelector != null) { IslandSelector.LookAtCalling(domain); }
-            
+
             var targetMat = GetTargetMaterials(domain.OriginEqual, domain.EnumerateRenderer());
             var gradTex = GradientToTextureWithTemp(Gradient, Alpha);
             var space = new SingleGradientSpace(transform.worldToLocalMatrix);

--- a/Runtime/Decal/SimpleDecal.cs
+++ b/Runtime/Decal/SimpleDecal.cs
@@ -62,11 +62,11 @@ namespace net.rs64.TexTransTool.Decal
 
         internal override void Apply(IDomain domain)
         {
+            domain.LookAt(this);
             if (!IsPossibleApply) { TTTRuntimeLog.Error(GetType().Name + ":error:TTTNotExecutable"); return; }
             var targetRenderers = domain.GetDomainsRenderers(TargetRenderers);
             var decalCompiledTextures = CompileDecal(targetRenderers, domain);
 
-            domain.LookAt(this);
             domain.LookAt(transform.GetParents().Append(transform));
             domain.LookAt(decalCompiledTextures.Keys);
             if (IslandSelector != null) { IslandSelector.LookAtCalling(domain); }

--- a/Runtime/Decal/SimpleDecal.cs
+++ b/Runtime/Decal/SimpleDecal.cs
@@ -66,10 +66,11 @@ namespace net.rs64.TexTransTool.Decal
             var targetRenderers = domain.GetDomainsRenderers(TargetRenderers);
             var decalCompiledTextures = CompileDecal(targetRenderers, domain);
 
+            domain.LookAt(this);
             domain.LookAt(transform.GetParents().Append(transform));
             domain.LookAt(decalCompiledTextures.Keys);
             if (IslandSelector != null) { IslandSelector.LookAtCalling(domain); }
-            
+
             foreach (var matAndTex in decalCompiledTextures)
             {
                 domain.AddTextureStack(matAndTex.Key.GetTexture(TargetPropertyName), new TextureBlend.BlendTexturePair(matAndTex.Value, BlendTypeKey));

--- a/Runtime/IDomain.cs
+++ b/Runtime/IDomain.cs
@@ -35,7 +35,7 @@ namespace net.rs64.TexTransTool
         //今後テクスチャとメッシュとマテリアル以外で置き換えが必要になった時できるようにするために用意はしておく
         void RegisterReplace(UnityEngine.Object oldObject, UnityEngine.Object nowObject);
     }
-    internal interface ILookingObject
+    public interface ILookingObject
     {
         void LookAt(UnityEngine.Object obj) { }
     }

--- a/Runtime/IslandSelect/AbstructIslandSelector.cs
+++ b/Runtime/IslandSelect/AbstructIslandSelector.cs
@@ -16,9 +16,8 @@ namespace net.rs64.TexTransTool.IslandSelector
         [HideInInspector, SerializeField] int _saveDataVersion = TexTransBehavior.TTTDataVersion;
         int ITexTransToolTag.SaveDataVersion => _saveDataVersion;
 
-        internal abstract IEnumerable<UnityEngine.Object> GetDependency();
+        internal abstract void LookAtCalling(ILookingObject looker);
 
-        internal abstract int GetDependencyHash();
 
         internal abstract BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription);
         BitArray IIslandSelector.IslandSelect(Island[] islands, IslandDescription[] islandDescription) => IslandSelect(islands, islandDescription);
@@ -31,25 +30,11 @@ namespace net.rs64.TexTransTool.IslandSelector
 
         internal abstract void OnDrawGizmosSelected();
 
-
-        internal static IEnumerable<UnityEngine.Object> ChildeDependency(AbstractIslandSelector abstractIslandSelector)
-        {
-            var chiles = TexTransGroup.GetChildeComponent<AbstractIslandSelector>(abstractIslandSelector.transform);
-            foreach (var chile in chiles)
-            {
-                yield return chile;
-                foreach (var cd in chile.GetDependency()) { yield return cd; }
-            }
-        }
-        internal static int ChildeDependencyHash(AbstractIslandSelector abstractIslandSelector)
+        internal static int LookAtChildren(AbstractIslandSelector abstractIslandSelector, ILookingObject lookingObject)
         {
             var hash = 0;
             var chiles = TexTransGroup.GetChildeComponent<AbstractIslandSelector>(abstractIslandSelector.transform);
-            foreach (var chile in chiles)
-            {
-                hash ^= chile?.GetInstanceID() ?? 0;
-                hash ^= chile?.GetDependencyHash() ?? 0;
-            }
+            foreach (var chile in chiles) { chile.LookAtCalling(lookingObject); }
             return hash;
         }
     }

--- a/Runtime/IslandSelect/BoxIslandSelector.cs
+++ b/Runtime/IslandSelect/BoxIslandSelector.cs
@@ -15,9 +15,11 @@ namespace net.rs64.TexTransTool.IslandSelector
 
         public bool IsAll;
 
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return transform.GetParents().Append(transform); }
-
-        internal override int GetDependencyHash() { return 0; }
+        internal override void LookAtCalling(ILookingObject looker)
+        {
+            looker.LookAt(transform.GetParents().Append(transform));
+            looker.LookAt(this);
+        }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             var bitArray = new BitArray(islands.Length);

--- a/Runtime/IslandSelect/IslandSelectorAND.cs
+++ b/Runtime/IslandSelect/IslandSelectorAND.cs
@@ -12,10 +12,8 @@ namespace net.rs64.TexTransTool.IslandSelector
     {
         internal const string ComponentName = "TTT IslandSelectorAND";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return ChildeDependency(this); }
 
-        internal override int GetDependencyHash() { return ChildeDependencyHash(this); }
-
+        internal override void LookAtCalling(ILookingObject looker) { LookAtChildren(this, looker); }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             BitArray bitArray = null;

--- a/Runtime/IslandSelect/IslandSelectorNOT.cs
+++ b/Runtime/IslandSelect/IslandSelectorNOT.cs
@@ -13,22 +13,7 @@ namespace net.rs64.TexTransTool.IslandSelector
         internal const string ComponentName = "TTT IslandSelectorNOT";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
 
-        internal override IEnumerable<UnityEngine.Object> GetDependency()
-        {
-            var islandSelector = GetIslandSelector();
-            if (islandSelector != null)
-            {
-                yield return islandSelector;
-                foreach (var depend in islandSelector.GetDependency()) { yield return depend; }
-            }
-        }
-
-        internal override int GetDependencyHash()
-        {
-            var islandSelector = GetIslandSelector();
-            return (islandSelector?.GetInstanceID() ?? 0) ^ (islandSelector?.GetDependencyHash() ?? 0);
-        }
-
+        internal override void LookAtCalling(ILookingObject looker) { GetIslandSelector().LookAtCalling(looker); }
         internal AbstractIslandSelector GetIslandSelector()
         {
             var childeCount = transform.childCount;

--- a/Runtime/IslandSelect/IslandSelectorOR.cs
+++ b/Runtime/IslandSelect/IslandSelectorOR.cs
@@ -12,8 +12,7 @@ namespace net.rs64.TexTransTool.IslandSelector
     {
         internal const string ComponentName = "TTT IslandSelectorOR";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return ChildeDependency(this); }
-        internal override int GetDependencyHash() { return ChildeDependencyHash(this); }
+        internal override void LookAtCalling(ILookingObject looker) { LookAtChildren(this, looker); }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             BitArray bitArray = null;

--- a/Runtime/IslandSelect/IslandSelectorXOR.cs
+++ b/Runtime/IslandSelect/IslandSelectorXOR.cs
@@ -13,8 +13,7 @@ namespace net.rs64.TexTransTool.IslandSelector
         internal const string ComponentName = "TTT IslandSelectorXOR";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
 
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return ChildeDependency(this); }
-        internal override int GetDependencyHash() { return ChildeDependencyHash(this); }
+        internal override void LookAtCalling(ILookingObject looker) { LookAtChildren(this, looker); }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             BitArray bitArray = null;

--- a/Runtime/IslandSelect/RayCastIslandSelector.cs
+++ b/Runtime/IslandSelect/RayCastIslandSelector.cs
@@ -16,8 +16,11 @@ namespace net.rs64.TexTransTool.IslandSelector
         internal const string ComponentName = "TTT RayCastIslandSelector";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
         public float IslandSelectorRange = 0.1f;
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return transform.GetParents().Append(transform); }
-        internal override int GetDependencyHash() { return 0; }
+        internal override void LookAtCalling(ILookingObject looker)
+        {
+            looker.LookAt(transform.GetParents().Append(transform));
+            looker.LookAt(this);
+        }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             return RayCastIslandSelect(GetIslandSelectorRay(), islands, islandDescription);

--- a/Runtime/IslandSelect/RendererIslandSelector.cs
+++ b/Runtime/IslandSelect/RendererIslandSelector.cs
@@ -12,13 +12,7 @@ namespace net.rs64.TexTransTool.IslandSelector
     {
         internal const string ComponentName = "TTT RendererIslandSelector";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { yield break; }
-        internal override int GetDependencyHash()
-        {
-            var hash = 0;
-            foreach (var r in RendererList) { hash ^= r?.GetInstanceID() ?? 0; }
-            return hash;
-        }
+        internal override void LookAtCalling(ILookingObject looker) { looker.LookAt(this); }
         public List<Renderer> RendererList;
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {

--- a/Runtime/IslandSelect/SphereIslandSelector.cs
+++ b/Runtime/IslandSelect/SphereIslandSelector.cs
@@ -13,9 +13,11 @@ namespace net.rs64.TexTransTool.IslandSelector
         internal const string ComponentName = "TTT SphereIslandSelector";
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
         public bool IsAll;
-
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return transform.GetParents().Append(transform); }
-        internal override int GetDependencyHash() { return 0; }
+        internal override void LookAtCalling(ILookingObject looker)
+        {
+            looker.LookAt(transform.GetParents().Append(transform));
+            looker.LookAt(this);
+        }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             var bitArray = new BitArray(islands.Length);

--- a/Runtime/IslandSelect/SubMeshIslandSelector.cs
+++ b/Runtime/IslandSelect/SubMeshIslandSelector.cs
@@ -13,9 +13,7 @@ namespace net.rs64.TexTransTool.IslandSelector
         internal const string MenuPath = FoldoutName + "/" + ComponentName;
 
         public int SelectSubMeshIndex = 0;
-
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { yield break; }
-        internal override int GetDependencyHash() { return 0; }
+        internal override void LookAtCalling(ILookingObject looker) { looker.LookAt(this); }
         internal override BitArray IslandSelect(Island[] islands, IslandDescription[] islandDescription)
         {
             var bitArray = new BitArray(islands.Length);

--- a/Runtime/MultiLayerImage/AbstractLayer.cs
+++ b/Runtime/MultiLayerImage/AbstractLayer.cs
@@ -36,15 +36,10 @@ namespace net.rs64.TexTransTool.MultiLayerImage
             }
         }
 
-        internal virtual IEnumerable<UnityEngine.Object> GetDependency()
+        internal virtual void LookAtCalling(ILookingObject lookingObject)
         {
-            yield return gameObject;
-            foreach (var m in LayerMask.GetDependency()) { yield return m; }
-        }
-
-        internal virtual int GetDependencyHash()
-        {
-            return LayerMask.GetDependencyHash();
+            lookingObject.LookAt(gameObject);
+            LayerMask.LookAtCalling(lookingObject);
         }
     }
     [Serializable]
@@ -55,9 +50,7 @@ namespace net.rs64.TexTransTool.MultiLayerImage
 
         public bool ContainedMask => !LayerMaskDisabled && MaskTexture != null;
 
-        public IEnumerable<UnityEngine.Object> GetDependency() { yield return MaskTexture; }
-
-        public int GetDependencyHash() { return MaskTexture?.GetInstanceID() ?? 0; }
+        public void LookAtCalling(ILookingObject lookingObject) { lookingObject.LookAt(MaskTexture); }
 
         void ILayerMask.WriteMaskTexture(RenderTexture renderTexture, IOriginTexture originTexture)
         {
@@ -69,8 +62,7 @@ namespace net.rs64.TexTransTool.MultiLayerImage
     {
         bool ContainedMask { get; }
         void WriteMaskTexture(RenderTexture renderTexture, IOriginTexture originTexture);
-        abstract IEnumerable<UnityEngine.Object> GetDependency();
-        int GetDependencyHash();
+        void LookAtCalling(ILookingObject lookingObject);
     }
 
 

--- a/Runtime/MultiLayerImage/LayerFolder.cs
+++ b/Runtime/MultiLayerImage/LayerFolder.cs
@@ -56,19 +56,10 @@ namespace net.rs64.TexTransTool.MultiLayerImage
             .Reverse();
         }
 
-        internal override IEnumerable<UnityEngine.Object> GetDependency()
+        internal override void LookAtCalling(ILookingObject lookingObject)
         {
-            var chileLayers = GetChileLayers();
-            return base.GetDependency().Concat(chileLayers).Concat(chileLayers.SelectMany(l => l.GetDependency()));
-        }
-        internal override int GetDependencyHash()
-        {
-            var hash = base.GetDependencyHash();
-            foreach (var cl in GetChileLayers())
-            {
-                hash ^= cl.GetDependencyHash();
-            }
-            return hash;
+            base.LookAtCalling(lookingObject);
+            foreach (var cl in GetChileLayers()) { cl.LookAtCalling(lookingObject); }
         }
     }
 

--- a/Runtime/MultiLayerImage/MultiLayerImageCanvas.cs
+++ b/Runtime/MultiLayerImage/MultiLayerImageCanvas.cs
@@ -27,6 +27,11 @@ namespace net.rs64.TexTransTool.MultiLayerImage
         internal override void Apply([NotNull] IDomain domain)
         {
             if (!IsPossibleApply) { throw new TTTNotExecutable(); }
+
+            TextureSelector.LookAtCalling(domain);
+            domain.LookAt(this);
+            foreach (var cl in GetChileLayers()) { cl.LookAtCalling(domain); }
+
             var replaceTarget = TextureSelector.GetTexture();
             var canvasSize = tttImportedCanvasDescription?.Width ?? NormalizePowOfTow(replaceTarget.width);
             if (domain.IsPreview()) { canvasSize = Mathf.Min(1024, canvasSize); }
@@ -67,23 +72,6 @@ namespace net.rs64.TexTransTool.MultiLayerImage
             if (Mathf.Abs(nextV - v) > Mathf.Abs(closetV - v)) { return closetV; }
             else { return nextV; }
         }
-
-        internal override IEnumerable<UnityEngine.Object> GetDependency(IDomain domain)
-        {
-            var chileLayers = GetChileLayers();
-            return TextureSelector.GetDependency().Append(tttImportedCanvasDescription).Concat(chileLayers).Concat(chileLayers.SelectMany(l => l.GetDependency()));
-        }
-
-        internal override int GetDependencyHash(IDomain domain)
-        {
-            var hash = TextureSelector.GetDependencyHash();
-            foreach (var cl in GetChileLayers())
-            {
-                hash ^= cl.GetDependencyHash();
-            }
-            return hash;
-        }
-
         internal class CanvasContext
         {
             public ITextureManager TextureManager;

--- a/Runtime/MultiLayerImage/RasterImportedLayer.cs
+++ b/Runtime/MultiLayerImage/RasterImportedLayer.cs
@@ -19,9 +19,11 @@ namespace net.rs64.TexTransTool.MultiLayerImage
         {
             originTexture.WriteOriginalTexture(ImportedImage, renderTexture);
         }
-
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return base.GetDependency().Append(ImportedImage); }
-        internal override int GetDependencyHash() { return base.GetDependencyHash() ^ ImportedImage?.GetInstanceID() ?? 0; }
+        internal override void LookAtCalling(ILookingObject lookingObject)
+        {
+            base.LookAtCalling(lookingObject);
+            lookingObject.LookAt(ImportedImage);
+        }
     }
     [Serializable]
     public class TTTImportedLayerMask : ILayerMask
@@ -41,8 +43,6 @@ namespace net.rs64.TexTransTool.MultiLayerImage
         {
             originTexture.WriteOriginalTexture(MaskTexture, renderTexture);
         }
-        public IEnumerable<UnityEngine.Object> GetDependency() { yield return MaskTexture; }
-
-        public int GetDependencyHash() { return MaskTexture?.GetInstanceID() ?? 0; }
+        public void LookAtCalling(ILookingObject lookingObject) { lookingObject.LookAt(MaskTexture); }
     }
 }

--- a/Runtime/MultiLayerImage/RasterLayer.cs
+++ b/Runtime/MultiLayerImage/RasterLayer.cs
@@ -14,7 +14,10 @@ namespace net.rs64.TexTransTool.MultiLayerImage
         {
             originTexture.WriteOriginalTexture(RasterTexture, renderTexture);
         }
-        internal override IEnumerable<UnityEngine.Object> GetDependency() { return base.GetDependency().Append(RasterTexture); }
-        internal override int GetDependencyHash() { return base.GetDependencyHash() ^ RasterTexture?.GetInstanceID() ?? 0; }
+        internal override void LookAtCalling(ILookingObject lookingObject)
+        {
+            base.LookAtCalling(lookingObject);
+            lookingObject.LookAt(RasterTexture);
+        }
     }
 }

--- a/Runtime/TexTransRuntimeBehavior.cs
+++ b/Runtime/TexTransRuntimeBehavior.cs
@@ -15,11 +15,5 @@ namespace net.rs64.TexTransTool
         internal abstract void Apply([NotNull] IDomain domain);
 
         internal abstract IEnumerable<Renderer> ModificationTargetRenderers(IEnumerable<Renderer> domainRenderers, OriginEqual replaceTracking);
-
-        /// <summary>
-        /// Enumerates references that depend on the component externally.
-        /// </summary>
-        internal abstract IEnumerable<UnityEngine.Object> GetDependency(IDomain domain);
-        internal abstract int GetDependencyHash(IDomain domain);
     }
 }

--- a/Runtime/TextureAtlas/AtlasTexture.cs
+++ b/Runtime/TextureAtlas/AtlasTexture.cs
@@ -828,25 +828,6 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
             return true;
         }
-
-        internal override IEnumerable<UnityEngine.Object> GetDependency(IDomain domain)
-        {
-            return AtlasSetting.IslandFineTuners.SelectMany(i => i.GetDependency())
-            .Concat(AtlasSetting.MaterialMergeGroups.Select(m => m.MergeReferenceMaterial))
-            .Append(AtlasSetting.AtlasIslandRelocator)
-            .Append(AtlasSetting.MergeReferenceMaterial);
-        }
-
-        internal override int GetDependencyHash(IDomain domain)
-        {
-            var hash = 0;
-            foreach (var ift in AtlasSetting.IslandFineTuners) { hash ^= ift.GetDependencyHash(); }
-            foreach (var mmg in AtlasSetting.MaterialMergeGroups) { hash ^= mmg.MergeReferenceMaterial?.GetInstanceID() ?? 0; }
-            hash ^= AtlasSetting.AtlasIslandRelocator?.GetInstanceID() ?? 0;
-            hash ^= AtlasSetting.MergeReferenceMaterial?.GetInstanceID() ?? 0;
-            return hash;
-        }
-
         internal override IEnumerable<Renderer> ModificationTargetRenderers(IEnumerable<Renderer> domainRenderers, OriginEqual replaceTracking)
         {
 

--- a/Runtime/TextureAtlas/IslandFineTuner/IIslandFineTuner.cs
+++ b/Runtime/TextureAtlas/IslandFineTuner/IIslandFineTuner.cs
@@ -13,7 +13,6 @@ namespace net.rs64.TexTransTool.TextureAtlas.IslandFineTuner
         //sizePriority と islandRect を操作して調整していく感じ
         void IslandFineTuning(float[] sizePriority, Island[] islands, IslandDescription[] islandDescriptions, IReplaceTracking replaceTracking);
 
-        IEnumerable<UnityEngine.Object> GetDependency();
-        int GetDependencyHash();
+        void LookAtCalling(ILookingObject looker);
     }
 }

--- a/Runtime/TextureAtlas/IslandFineTuner/SizePriority.cs
+++ b/Runtime/TextureAtlas/IslandFineTuner/SizePriority.cs
@@ -13,9 +13,7 @@ namespace net.rs64.TexTransTool.TextureAtlas.IslandFineTuner
         [Range(0, 1)] public float PriorityValue = 1f;
         public AbstractIslandSelector IslandSelector;
 
-        public IEnumerable<UnityEngine.Object> GetDependency() { return IslandSelector.GetDependency(); }
-
-        public int GetDependencyHash() { return IslandSelector.GetDependencyHash(); }
+        public void LookAtCalling(ILookingObject lookingObject) { if (IslandSelector != null) { IslandSelector.LookAtCalling(lookingObject); } }
         public void IslandFineTuning(float[] sizePriority, Island[] islands, IslandDescription[] islandDescriptions, IReplaceTracking replaceTracking)
         {
             var targetBit = IslandSelector.IslandSelect(islands, islandDescriptions);


### PR DESCRIPTION
GetDependency と Domainでの LookAt の役割が重複しているから、RealTimePreviewでの依存性の調査を LookAt を使う形にする。