### PR TITLE
fix: texture turn black when texture UpScaling

### DIFF
--- a/CHANGELOG-EXPERIMENTAL.md
+++ b/CHANGELOG-EXPERIMENTAL.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - TextureBlender TextureSelector が Absolute の場合、SelectTexture を割り当てても実行できない問題を修正 (#560)
 - AtlasTexture TextureFineTuning MergeTexture で MergeParent を存在しないものに指定した場合に例外が発生する問題を修正 (#561)
 - TextureConfigurator で OverrideCompression は有効だが、OverrideTextureSetting が無効な場合に解像度や MipMap の有無が正しくないテクスチャが生成される問題を修正 (#573)
+- TextureConfigurator でもともとのテクスチャよりも大きい解像度を指定した場合に MipMap の0番あたりが黒くなってしまう問題を修正 (#580)
 
 ## [v0.7.7](https://github.com/ReinaS-64892/TexTransTool/compare/v0.7.6...v0.7.7) - 2024-07-24
 

--- a/Runtime/CommonComponent/TextureConfigurator.cs
+++ b/Runtime/CommonComponent/TextureConfigurator.cs
@@ -55,25 +55,32 @@ namespace net.rs64.TexTransTool
                 var aspect = targetTex2D.height / targetTex2D.width;
                 var originalSize = textureManager.GetOriginalTextureSize(targetTex2D);
 
-                using (TTRt.U(out var originRt, originalSize, Mathf.RoundToInt(aspect * originalSize), true, false, true, true))
                 using (TTRt.U(out var newTempRt, TextureSize, Mathf.RoundToInt(aspect * TextureSize), true, false, MipMap, MipMap))
                 {
-                    textureManager.WriteOriginalTexture(targetTex2D, originRt);
-                    MipMapUtility.GenerateMips(originRt, DownScalingAlgorism, !DownScalingWithLookAtAlpha);
-                    if (MipMap)
-                    {
-                        var originMipCount = originRt.mipmapCount;
-                        var targetSizeMipCount = newTempRt.mipmapCount;
-
-                        var copyMipIndex = 1;
-                        while ((originMipCount - copyMipIndex) >= 0 && (targetSizeMipCount - copyMipIndex) >= 0)
+                    if (originalSize >= TextureSize)
+                        using (TTRt.U(out var originRt, originalSize, Mathf.RoundToInt(aspect * originalSize), true, false, true, true))
                         {
-                            Graphics.CopyTexture(originRt, 0, originMipCount - copyMipIndex, newTempRt, 0, targetSizeMipCount - copyMipIndex);
-                            copyMipIndex += 1;
-                        }
-                    }
-                    else { Graphics.Blit(originRt, newTempRt); }
+                            textureManager.WriteOriginalTexture(targetTex2D, originRt);
+                            MipMapUtility.GenerateMips(originRt, DownScalingAlgorism, !DownScalingWithLookAtAlpha);
+                            if (MipMap)
+                            {
+                                var originMipCount = originRt.mipmapCount;
+                                var targetSizeMipCount = newTempRt.mipmapCount;
 
+                                var copyMipIndex = 1;
+                                while ((originMipCount - copyMipIndex) >= 0 && (targetSizeMipCount - copyMipIndex) >= 0)
+                                {
+                                    Graphics.CopyTexture(originRt, 0, originMipCount - copyMipIndex, newTempRt, 0, targetSizeMipCount - copyMipIndex);
+                                    copyMipIndex += 1;
+                                }
+                            }
+                            else { Graphics.Blit(originRt, newTempRt); }
+                        }
+                    else
+                    {
+                        textureManager.WriteOriginalTexture(targetTex2D, newTempRt);
+                        if (MipMap) MipMapUtility.GenerateMips(newTempRt, DownScalingAlgorism);
+                    }
                     newTexture2D = newTempRt.CopyTexture2D();
                 }
             }


### PR DESCRIPTION
#578 で発覚した TextureConfigurator がおおもとのサイズよりも大きい場合に map が存在しないために真っ黒になる問題の修正