### PR TITLE
fix: forget to looking child components of IslandSelector

### DIFF
--- a/CHANGELOG-EXPERIMENTAL.md
+++ b/CHANGELOG-EXPERIMENTAL.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - TTT PSD Importer 一部の PSD で ImageResourceBlock に Name が含まれている物の読み取りに失敗する問題を修正 (#632)
 - AtlasTexture MaterialMergeGroup の MergeReferenceMaterial が Null の場合例外が発生する問題を修正 (#636)
 - TTT PSD Importer 一部の PSD で 重複した色チャンネルを持つと主張する PSD の読み取りに失敗する問題を回避 (#638)
+- IslandSelectorOR などの子のコンポーネントを使用する IslandSelector が、子のコンポーネントの削除や増加を監視し忘れていた問題を修正 (#659)
 
 ## [v0.7.7](https://github.com/ReinaS-64892/TexTransTool/compare/v0.7.6...v0.7.7) - 2024-07-24
 

--- a/Runtime/IslandSelect/AbstructIslandSelector.cs
+++ b/Runtime/IslandSelect/AbstructIslandSelector.cs
@@ -35,6 +35,7 @@ namespace net.rs64.TexTransTool.IslandSelector
             var hash = 0;
             var chiles = TexTransGroup.GetChildeComponent<AbstractIslandSelector>(abstractIslandSelector.transform);
             foreach (var chile in chiles) { chile.LookAtCalling(lookingObject); }
+            lookingObject.LookAtChildeComponents<AbstractIslandSelector>(abstractIslandSelector.gameObject);
             return hash;
         }
     }


### PR DESCRIPTION
Fix #658 