### PR TITLE
perf: Load original textures in parallel

### DIFF
--- a/Editor/Domain/TextureManager.cs
+++ b/Editor/Domain/TextureManager.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using net.rs64.TexTransTool.MultiLayerImage;
 using net.rs64.TexTransTool.Utils;
 using UnityEditor;
@@ -41,6 +41,10 @@ namespace net.rs64.TexTransTool
         public int GetOriginalTextureSize(Texture2D texture2D) { return _originTexture.GetOriginalTextureSize(texture2D); }
         public void WriteOriginalTexture(Texture2D texture2D, RenderTexture writeTarget) { _originTexture.WriteOriginalTexture(texture2D, writeTarget); }
         public void WriteOriginalTexture(TTTImportedImage texture, RenderTexture writeTarget) { _originTexture.WriteOriginalTexture(texture, writeTarget); }
+        public void PreloadOriginalTexture(Texture2D texture2D)
+        {
+            _originTexture.PreloadOriginalTexture(texture2D);
+        }
     }
 
     internal class DeferredDestroyer : IDeferredDestroyTexture
@@ -75,11 +79,24 @@ namespace net.rs64.TexTransTool
         }
 
         protected Dictionary<Texture2D, Texture2D> _originDict = new();
+
+        private Dictionary<Texture2D, Task<Func<Texture2D>>> _asyncOriginLoaders = new();
+        
         protected Dictionary<TTTImportedCanvasDescription, byte[]> _canvasSource = new();
 
         public IReadOnlyDictionary<Texture2D, Texture2D> OriginDict => _originDict;
         public IReadOnlyDictionary<TTTImportedCanvasDescription, byte[]> CanvasSource => _canvasSource;
 
+        
+        public void PreloadOriginalTexture(Texture2D texture2D)
+        {
+            if (_originDict.ContainsKey(texture2D) || _asyncOriginLoaders.ContainsKey(texture2D)) return;
+
+            var task = TextureUtility.AsyncGetUncompressed(texture2D);
+
+            _asyncOriginLoaders[texture2D] = task;
+        }
+        
         public void WriteOriginalTexture(Texture2D texture2D, RenderTexture writeTarget)
         {
             Graphics.Blit(GetOriginalTexture(texture2D), writeTarget);
@@ -96,6 +113,8 @@ namespace net.rs64.TexTransTool
                 texture.LoadImage(_canvasSource[texture.CanvasDescription], writeTarget);
             }
         }
+
+
         public int GetOriginalTextureSize(Texture2D texture2D)
         {
             return TexTransCore.Utils.TextureUtility.NormalizePowerOfTwo(GetOriginalTexture(texture2D).width);
@@ -110,6 +129,22 @@ namespace net.rs64.TexTransTool
             {
                 if (_originDict.ContainsKey(texture2D) && _originDict[texture2D] != null)
                 {
+                    return _originDict[texture2D];
+                }
+                else if (_asyncOriginLoaders.TryGetValue(texture2D, out var task))
+                {
+                    // 必要なテクスチャの読み込み終わってない間に他のテクスチャをApplyしましょう、と思いきや、それでは遅くなります。
+                    // おそらく、まだ必要じゃないテクスチャのアップロードを待つことで、今できるBlitが後回しになっているからだと思われます。
+                    // なので、テクスチャが初めて必要になったときにApplyする方針です。
+                    if (!task.Wait(60_000))
+                    {
+                        // なんか壊れたらEditorが固まらないための安全装置
+                        throw new TimeoutException("Async image loader timed out");
+                    }
+                    _originDict[texture2D] = task.Result();
+                    DeferDestroyCall?.Invoke(_originDict[texture2D]);
+                    _asyncOriginLoaders.Remove(texture2D);
+                    
                     return _originDict[texture2D];
                 }
                 else

--- a/Editor/Utils/TextureUtility.cs
+++ b/Editor/Utils/TextureUtility.cs
@@ -1,29 +1,148 @@
 using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using net.rs64.TexTransCore;
 using net.rs64.TexTransCore.Utils;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Profiling;
+using Graphics = UnityEngine.Graphics;
 
 namespace net.rs64.TexTransTool.Utils
 {
 
     internal static class TextureUtility
     {
+        public static Task<Func<Texture2D>> AsyncGetUncompressed(Texture2D firstTexture)
+        {
+            Func<Texture2D> origTexReturn = () => firstTexture;
+            Task<Func<Texture2D>> origTexTask = Task.FromResult(origTexReturn);
+            
+            if (!AssetDatabase.Contains(firstTexture)) { return origTexTask; }
+
+            var path = AssetDatabase.GetAssetPath(firstTexture);
+
+            if (!(Path.GetExtension(path) == ".png" || Path.GetExtension(path) == ".jpeg" ||
+                  Path.GetExtension(path) == ".jpg"))
+            {
+                return origTexTask;
+            }
+            
+            var importer = AssetImporter.GetAtPath(path) as TextureImporter;
+            if (importer == null || importer.textureType != TextureImporterType.Default)
+            {
+                return origTexTask;
+            }
+            
+            // Start async texture loading
+            Profiler.BeginSample("CoGetUncompressed.Sync", firstTexture);
+            Bitmap bitmap;
+            Texture2D texture;
+            NativeArray<UInt32> rawTexData;
+            try
+            {
+                bitmap = new Bitmap(path);
+                // Note: Unity and C# use different endianness for Texture2D data (at least on x86_64 windows).
+                texture = new Texture2D(bitmap.Width, bitmap.Height, TextureFormat.BGRA32, true, false, true);
+                rawTexData = texture.GetRawTextureData<UInt32>();
+            }
+            finally
+            {
+                Profiler.EndSample();
+            }
+
+            if (rawTexData.Length < bitmap.Width * bitmap.Height)
+            {
+                throw new Exception($"rawTexData.Length {rawTexData.Length} < bitmap.Width {bitmap.Width} * bitmap.Height {bitmap.Height} * 4 [{texture.width} x {texture.height}]");
+            }
+
+            // Run on C# thread pool, not Unity's main thread
+            var syncContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            
+            var task = Task.Run(() =>
+            {
+                RuntimeHelpers.GetHashCode(texture); // force texture to not be GC'd until this task completes
+
+                try
+                {
+                    unsafe
+                    {
+                        var data = new BitmapData()
+                        {
+                            Height = bitmap.Height,
+                            Width = bitmap.Width,
+                            // Unity and C#'s System.Drawing use a different vertical order for pixels, so set a negative
+                            // stride to flip the image vertically.
+                            Stride = bitmap.Width * -4,
+                            Scan0 = (IntPtr)rawTexData.GetUnsafePtr() + bitmap.Width * (bitmap.Height - 1) * 4,
+                            PixelFormat = PixelFormat.Format32bppArgb
+                        };
+                        
+                        Profiler.BeginSample("TryGetUnCompress.LockBits", firstTexture);
+                        var locked = bitmap.LockBits(
+                            new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                            ImageLockMode.ReadOnly | ImageLockMode.UserInputBuffer,
+                            PixelFormat.Format32bppArgb,
+                            data
+                        );
+                        bitmap.UnlockBits(locked);
+                        Profiler.EndSample();
+                    }
+                }
+                finally
+                {
+                    bitmap.Dispose();
+                }
+            });
+
+            var timeout = Task.Delay(10_000);
+            var anyCompleted = Task.WhenAny(task, timeout);
+
+            var result = anyCompleted.ContinueWith(_ =>
+            {
+                if (!task.IsCompleted)
+                {
+                    Debug.LogError($"Texture loading timed out: {path}");
+                    return origTexReturn;
+                }
+
+                return () =>
+                {
+                    Profiler.BeginSample("TryGetUnCompress.Apply", firstTexture);
+                    texture.Apply(true);
+                    Profiler.EndSample();
+
+                    return texture;
+                };
+            });
+            
+            SynchronizationContext.SetSynchronizationContext(syncContext);
+
+            return result;
+        }
+
         public static bool TryGetUnCompress(Texture2D firstTexture, out Texture2D unCompress)
         {
-            if (!AssetDatabase.Contains(firstTexture)) { unCompress = firstTexture; return false; }
-            var path = AssetDatabase.GetAssetPath(firstTexture);
-            if (Path.GetExtension(path) == ".png" || Path.GetExtension(path) == ".jpeg" || Path.GetExtension(path) == ".jpg")
+            var task = AsyncGetUncompressed(firstTexture);
+            if (!task.Wait(60_000))
             {
-                var importer = AssetImporter.GetAtPath(path) as TextureImporter;
-                if (importer == null || importer.textureType != TextureImporterType.Default) { unCompress = firstTexture; return false; }
-                unCompress = new Texture2D(2, 2);
-                unCompress.LoadImage(File.ReadAllBytes(path));
-                return true;
+                throw new TimeoutException("Texture loading timed out");
             }
-            else { unCompress = firstTexture; return false; }
+            
+            unCompress = task.Result();
+
+            return unCompress != firstTexture;
         }
 
         public static Texture2D TryGetUnCompress(this Texture2D tex)

--- a/Editor/net.rs64.tex-trans-tool.editor.asmdef
+++ b/Editor/net.rs64.tex-trans-tool.editor.asmdef
@@ -15,7 +15,7 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,

--- a/Runtime/IDomain.cs
+++ b/Runtime/IDomain.cs
@@ -52,6 +52,8 @@ namespace net.rs64.TexTransTool
         int GetOriginalTextureSize(Texture2D texture2D);
         void WriteOriginalTexture(Texture2D texture2D, RenderTexture writeTarget);
         void WriteOriginalTexture(TTTImportedImage texture, RenderTexture writeTarget);
+
+        void PreloadOriginalTexture(Texture2D texture2D);
     }
     public interface IDeferTextureCompress
     {

--- a/Runtime/TextureAtlas/AtlasTexture.cs
+++ b/Runtime/TextureAtlas/AtlasTexture.cs
@@ -517,6 +517,14 @@ namespace net.rs64.TexTransTool.TextureAtlas
         }
         private static Dictionary<int, Dictionary<string, RenderTexture>> GetGroupedTextures(ITextureManager texManage, AtlasSetting atlasSetting, AtlasContext atlasContext, PropertyBakeSetting propertyBakeSetting, out HashSet<string> property, out Dictionary<string, float> bakePropMaxValue)
         {
+            foreach (var textures in atlasContext.MaterialGroupToAtlasShaderTexDict.Values)
+            {
+                foreach (var atlasShaderTexture in textures.Values)
+                {
+                    if (atlasShaderTexture.Texture is Texture2D tex) texManage.PreloadOriginalTexture(tex);
+                }
+            }
+            
             bakePropMaxValue = null;
             var downScalingAlgorithm = atlasSetting.DownScalingAlgorithm;
             switch (propertyBakeSetting)
@@ -661,29 +669,49 @@ namespace net.rs64.TexTransTool.TextureAtlas
 
         private static RenderTexture GetOriginAtUseMip(ITextureManager texManage, Texture atlasTex)
         {
-            switch (atlasTex)
+            Profiler.BeginSample("GetOriginAtUseMip");
+            try
             {
-                default:
+                switch (atlasTex)
+                {
+                    default:
                     {
                         var originSize = atlasTex.width;
+                        Profiler.BeginSample("TTTRt.G");
                         var rt = TTRt.G(originSize, originSize, true, false, true, true);
+                        Profiler.EndSample();
                         rt.name = $"{atlasTex.name}:GetOriginAtUseMip-TempRt-{rt.width}x{rt.height}";
                         rt.CopyFilWrap(atlasTex);
                         rt.filterMode = FilterMode.Trilinear;
+                        Profiler.BeginSample("Graphics.Blit");
                         Graphics.Blit(atlasTex, rt);
+                        Profiler.EndSample();
                         return rt;
                     }
-                case Texture2D atlasTex2D:
+                    case Texture2D atlasTex2D:
                     {
+                        Profiler.BeginSample("GetOriginalTextureSize");
                         var originSize = texManage.GetOriginalTextureSize(atlasTex2D);
+                        Profiler.EndSample();
+                        
+                        Profiler.BeginSample("TTTRt.G");
                         var rt = TTRt.G(originSize, originSize, true, false, true, true);
+                        Profiler.EndSample();
                         rt.name = $"{atlasTex.name}:GetOriginAtUseMip-TempRt-{rt.width}x{rt.height}";
                         rt.CopyFilWrap(atlasTex);
                         rt.filterMode = FilterMode.Trilinear;
+                        Profiler.BeginSample("Graphics.Blit");
                         texManage.WriteOriginalTexture(atlasTex2D, rt);
+                        Profiler.EndSample();
                         return rt;
                     }
 
+                }
+            }
+            finally
+            {
+                
+                Profiler.EndSample();
             }
         }
         private static int GetNormalizedMinHeightSize(int atlasTextureSize, float height)

--- a/TexTransCore/MipMap/MipMapUtility.cs
+++ b/TexTransCore/MipMap/MipMapUtility.cs
@@ -5,6 +5,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 using UnityEngine;
+using UnityEngine.Profiling;
 using static Unity.Mathematics.math;
 using ReadOnlyAttribute = Unity.Collections.ReadOnlyAttribute;
 
@@ -25,6 +26,9 @@ namespace net.rs64.TexTransCore.MipMap
         public static bool GenerateMips(RenderTexture renderTexture, DownScalingAlgorithm algorism, bool ignoreAlpha = false)
         {
             if (!renderTexture.useMipMap || !renderTexture.enableRandomWrite) { return false; }
+            
+            Profiler.BeginSample("GenerateMips");
+            
             if (SystemInfo.supportsComputeShaders is false
             || SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore
             || SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3
@@ -36,6 +40,8 @@ namespace net.rs64.TexTransCore.MipMap
                 case DownScalingAlgorithm.Average: { result = Average(renderTexture, ignoreAlpha); break; }
                 default: { renderTexture.GenerateMips(); result = true; break; }
             }
+            
+            Profiler.EndSample();
 
             return result;
         }


### PR DESCRIPTION
This change uses the C# drawing API to load and decompress original
textures in parallel on the C# task thread pool. On my avatar, this
reduces atlas processing time by half (1s of savings).

This change also adds some profiler scopes.
