### PR TITLE
chore: expose _useCustomProperty at PropertyName

### DIFF
--- a/Runtime/Common/PropertyName.cs
+++ b/Runtime/Common/PropertyName.cs
@@ -14,10 +14,10 @@ namespace net.rs64.TexTransTool
 #pragma warning restore CS0414 , IDE0052
 
 
-        public PropertyName(string propertyName)
+        public PropertyName(string propertyName, bool useCustomProperty = false)
         {
             _propertyName = propertyName;
-            _useCustomProperty = false;
+            _useCustomProperty = useCustomProperty;
             _shaderName = "DefaultShader";
         }
         internal bool UseCustomProperty => _useCustomProperty;


### PR DESCRIPTION
勝手に呼び出している身で申し訳ないのですが、RelativeモードのTextureSelectorをスクリプトから設定する関係でPropertyName._useCustomPropertyが設定可能だと助かるのでPRを出します。
もし可能な場合、v0.9.xにもマージしてくれると助かります。