### PR TITLE
perf: use the new NDMF AssetSaver API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/ReinaS-64892/TexTransTool/compare/v0.8.3...HEAD)
 
+### Added
+
+- NDMF v1.6.0 にて追加された AssetSaver API に対応 (#731)
+
 ## [v0.8.3](https://github.com/ReinaS-64892/TexTransTool/compare/v0.8.2...v0.8.3) - 2024-10-30
 
 ### Fixed

--- a/Editor/NDMF/NDMFDomain.cs
+++ b/Editor/NDMF/NDMFDomain.cs
@@ -1,5 +1,6 @@
 using nadena.dev.ndmf;
 using System;
+using UnityEditor;
 using Object = UnityEngine.Object;
 
 
@@ -7,7 +8,28 @@ namespace net.rs64.TexTransTool.NDMF
 {
     internal class NDMFDomain : AvatarDomain
     {
-        public NDMFDomain(BuildContext b) : base(b.AvatarRootObject, false, new AssetSaver(b.AssetContainer)) { }
+        private class NDMFAssetSaver : IAssetSaver
+        {
+            private readonly BuildContext _buildContext;
+            
+            public NDMFAssetSaver(BuildContext buildContext)
+            {
+                _buildContext = buildContext;
+            }
+            
+            public void TransferAsset(Object asset)
+            {
+                if (asset == null || AssetDatabase.Contains(asset)) return;
+                
+                #if NDMF_1_6_0_OR_NEWER
+                _buildContext.AssetSaver.SaveAsset(asset);
+                #else
+                AssetDatabase.AddObjectToAsset(asset, _buildContext.AssetContainer);
+                #endif
+            }
+        }
+        
+        public NDMFDomain(BuildContext b) : base(b.AvatarRootObject, false, new NDMFAssetSaver(b)) { }
 
         public override void RegisterReplace(Object oldObject, Object nowObject)
         {

--- a/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
+++ b/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
@@ -26,6 +26,11 @@
             "name": "nadena.dev.ndmf",
             "expression": "1.5.0",
             "define": "CONTAINS_NDMF"
+        },
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "1.6.0-a",
+            "define": "NDMF_1_6_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
+++ b/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
@@ -29,7 +29,7 @@
         },
         {
             "name": "nadena.dev.ndmf",
-            "expression": "1.6.0-a",
+            "expression": "1.6.0",
             "define": "NDMF_1_6_0_OR_NEWER"
         }
     ],


### PR DESCRIPTION
This change helps improve performance by avoiding having the AssetDatabase read a large
asset file containing textures when manipulating smaller assets such as animator
transitions. AssetSaver will automatically place each texture in a file on its own.
