### PR TITLE
feat: MaterialOverrideTransferMode.Record

### DIFF
--- a/Editor/EditorProcessor/MaterialOverrideTransferProcessor.cs
+++ b/Editor/EditorProcessor/MaterialOverrideTransferProcessor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using net.rs64.TexTransTool.Utils;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace net.rs64.TexTransTool.EditorProcessor
 {
@@ -14,71 +13,51 @@ namespace net.rs64.TexTransTool.EditorProcessor
         public void Process(TexTransCallEditorBehavior texTransCallEditorBehavior, IDomain domain)
         {
             var materialOverrideTransfer = texTransCallEditorBehavior as MaterialOverrideTransfer;
+            
+            if (materialOverrideTransfer.TargetMaterial == null) { TTTRuntimeLog.Info("MaterialOverrideTransfer:info:TargetNotSet"); return; }
+            if (materialOverrideTransfer.MaterialVariantSource == null) { TTTRuntimeLog.Info("MaterialOverrideTransfer:info:VariantNotSet"); return;}
 
-            var isValid = materialOverrideTransfer.TargetMaterial != null && materialOverrideTransfer.MaterialVariantSource != null;
-            if (materialOverrideTransfer.TargetMaterial == null) { TTTRuntimeLog.Info("MaterialOverrideTransfer:info:TargetNotSet"); }
-            if (materialOverrideTransfer.MaterialVariantSource == null) { TTTRuntimeLog.Info("MaterialOverrideTransfer:info:VariantNotSet"); }
-            if (isValid is false) { return; }
-
-            var materialVariantSource = materialOverrideTransfer.MaterialVariantSource;
             var mats = GetTargetMaterials(domain.EnumerateRenderer(), domain.OriginEqual, materialOverrideTransfer.TargetMaterial);
-
             if (mats.Any() is false) { TTTRuntimeLog.Info("MaterialOverrideTransfer:info:TargetNotFound"); return; }
-
-            var overridePropertyDict = new Dictionary<string, ShaderPropertyType>();
-            var shader = materialVariantSource.shader;
-            var pCount = shader.GetPropertyCount();
-            for (var i = 0; pCount > i; i += 1)
-            {
-                var propertyName = shader.GetPropertyName(i);
-                if (materialVariantSource.IsPropertyOverriden(propertyName)) { overridePropertyDict.Add(propertyName, shader.GetPropertyType(i)); }
-            }
 
             var materialSwapDict = new Dictionary<Material, Material>();
             foreach (var unEditableMat in mats)
             {
-                var mat = materialSwapDict[unEditableMat] = Material.Instantiate(unEditableMat);
-                foreach (var overrideProperty in overridePropertyDict)
-                {
-                    if (!mat.HasProperty(overrideProperty.Key)) { continue; }
-                    if (mat.shader.GetPropertyType(mat.shader.FindPropertyIndex(overrideProperty.Key)) != overrideProperty.Value) { continue; }
-
-                    switch (overrideProperty.Value)
-                    {
-                        case ShaderPropertyType.Texture:
-                            {
-                                mat.SetTexture(overrideProperty.Key, materialVariantSource.GetTexture(overrideProperty.Key));
-                                mat.SetTextureOffset(overrideProperty.Key, materialVariantSource.GetTextureOffset(overrideProperty.Key));
-                                mat.SetTextureScale(overrideProperty.Key, materialVariantSource.GetTextureScale(overrideProperty.Key));
-                                break;
-                            }
-                        case ShaderPropertyType.Color:
-                            {
-                                mat.SetColor(overrideProperty.Key, materialVariantSource.GetColor(overrideProperty.Key));
-                                break;
-                            }
-                        case ShaderPropertyType.Vector:
-                            {
-                                mat.SetVector(overrideProperty.Key, materialVariantSource.GetVector(overrideProperty.Key));
-                                break;
-                            }
-                        case ShaderPropertyType.Int:
-                            {
-                                mat.SetInt(overrideProperty.Key, materialVariantSource.GetInt(overrideProperty.Key));
-                                break;
-                            }
-                        case ShaderPropertyType.Float:
-                        case ShaderPropertyType.Range:
-                            {
-                                mat.SetFloat(overrideProperty.Key, materialVariantSource.GetFloat(overrideProperty.Key));
-                                break;
-                            }
-                    }
-                }
+                var mat = Material.Instantiate(unEditableMat);
+                var overrideProperties = GetOverrideProperties(materialOverrideTransfer.MaterialVariantSource);
+                SetProperties(mat, overrideProperties);
+                materialSwapDict[unEditableMat] = mat;
             }
-
             domain.ReplaceMaterials(materialSwapDict);
         }
+
+        public static void SetProperties(Material mat, IEnumerable<MaterialProperty> materialProperties)
+        {
+            foreach (var materialProperty in materialProperties)
+            {
+                materialProperty.Set(mat);
+            }
+        }
+
+        public static IEnumerable<MaterialProperty> GetOverrideProperties(Material variant)
+        {
+            if (variant == null) yield break;
+
+            var shader = variant.shader;
+            var pCount = shader.GetPropertyCount();
+            for (var i = 0; pCount > i; i += 1)
+            {
+                var propertyName = shader.GetPropertyName(i);
+                var propertyType = shader.GetPropertyType(i);
+
+                if (!variant.IsPropertyOverriden(propertyName)) continue;
+
+                if (!MaterialProperty.TryGet(variant, propertyName, propertyType, out var property)) continue;
+
+                yield return property;
+            }
+        }
+
 
         private static IEnumerable<Material> GetTargetMaterials(IEnumerable<Renderer> domainRenderer, OriginEqual originEqual, Material target)
         {

--- a/Editor/Inspector/MaterialOverrideTransferEditor.cs
+++ b/Editor/Inspector/MaterialOverrideTransferEditor.cs
@@ -1,0 +1,206 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+using net.rs64.TexTransTool.EditorProcessor;
+
+namespace net.rs64.TexTransTool.Editor
+{
+    [CustomEditor(typeof(MaterialOverrideTransfer))]
+    public class MaterialOverrideTransferEditor : UnityEditor.Editor
+    {
+        private MaterialOverrideTransfer _target;
+        private SerializedProperty _targetMaterial;
+        private SerializedProperty _mode;
+        private SerializedProperty _materialVariantSource;
+        private SerializedProperty _overrideShader;
+        private SerializedProperty _overrideProperties;
+        private UnityEditor.Editor _materialEditor;
+        private bool _showOverrides;
+
+        private void OnEnable()
+        {
+            _target = target as MaterialOverrideTransfer;
+            _targetMaterial = serializedObject.FindProperty(nameof(MaterialOverrideTransfer.TargetMaterial));
+            _mode = serializedObject.FindProperty(nameof(MaterialOverrideTransfer.Mode));
+            _materialVariantSource = serializedObject.FindProperty(nameof(MaterialOverrideTransfer.MaterialVariantSource));
+            _overrideShader = serializedObject.FindProperty(nameof(MaterialOverrideTransfer.OverrideShader));
+            _overrideProperties = serializedObject.FindProperty(nameof(MaterialOverrideTransfer.OverrideProperties));
+        }
+
+        private void OnDisable()
+        {
+            if (_materialEditor != null)
+            {
+                DestroyImmediate(_materialEditor);
+                _materialEditor = null;
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(_targetMaterial);
+            EditorGUILayout.PropertyField(_mode);
+
+            var mode = (MaterialOverrideTransferMode)_mode.enumValueIndex;
+            switch (mode)
+            {
+                case MaterialOverrideTransferMode.Variant:
+                    EditorGUILayout.PropertyField(_materialVariantSource);
+                    break;
+                case MaterialOverrideTransferMode.Record:
+                    EditMaterialGUI();
+                    var count = (_overrideShader.objectReferenceValue != null ? 1 : 0) + _overrideProperties.arraySize;
+                    _showOverrides = EditorGUILayout.Foldout(_showOverrides, $"Overrides: {count}");
+                    if (_showOverrides)
+                    {
+                        EditorGUI.indentLevel++;
+                        EditorGUILayout.PropertyField(_overrideShader);
+                        EditorGUILayout.PropertyField(_overrideProperties);
+                        EditorGUI.indentLevel--;
+                    }
+                    break;
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void EditMaterialGUI()
+        {
+            if (_target.TargetMaterial == null) return;
+
+            if (_target.IsRecording)
+            {
+                if (_target.TempMaterial == null) { StopEditing(); return; }
+
+                if (GUILayout.Button("Stop Editing"))
+                {
+                    StopEditing();
+                }
+                
+                _materialEditor ??= UnityEditor.Editor.CreateEditor(_target.TempMaterial);
+                _materialEditor?.DrawHeader ();
+                _materialEditor?.OnInspectorGUI (); 
+
+            }
+            else
+            {
+                if (GUILayout.Button("Start Editing"))
+                {
+                    StartEditing();
+                }
+            }
+        }
+
+        private void StartEditing()
+        {
+            _target.IsRecording = true;
+
+            _target.TempMaterial = Material.Instantiate(_target.TargetMaterial);
+            MaterialOverrideTransferProcessor.SetProperties(_target.TempMaterial, _target.OverrideProperties);
+            EditorUtility.SetDirty(_target);
+        }
+
+        private void StopEditing()
+        {
+            _target.IsRecording = false;
+
+            if (_target.TempMaterial != null)
+            {
+                _target.OverrideShader = _target.TargetMaterial.shader != _target.TempMaterial.shader ? _target.TempMaterial.shader : null;
+                _target.OverrideProperties = MaterialOverrideTransferProcessor.GetOverrideProperties(_target.TargetMaterial, _target.TempMaterial).ToList();
+                DestroyImmediate(_target.TempMaterial);
+                _target.TempMaterial = null;
+            }
+            EditorUtility.SetDirty(_target);
+
+            if (_materialEditor != null)
+            {
+                DestroyImmediate(_materialEditor);
+                _materialEditor = null;
+            }
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(MaterialProperty))]
+    internal class MaterialPropertyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            position.height = EditorGUIUtility.singleLineHeight;
+            
+            var propertyName = property.FindPropertyRelative(nameof(MaterialProperty.PropertyName));
+            var propertyType = property.FindPropertyRelative(nameof(MaterialProperty.PropertyType));
+            var textureValue = property.FindPropertyRelative(nameof(MaterialProperty.TextureValue));
+            var textureOffsetValue = property.FindPropertyRelative(nameof(MaterialProperty.TextureOffsetValue));
+            var textureScaleValue = property.FindPropertyRelative(nameof(MaterialProperty.TextureScaleValue));
+            var colorValue = property.FindPropertyRelative(nameof(MaterialProperty.ColorValue));
+            var vectorValue = property.FindPropertyRelative(nameof(MaterialProperty.VectorValue));
+            var intValue = property.FindPropertyRelative(nameof(MaterialProperty.IntValue));
+            var floatValue = property.FindPropertyRelative(nameof(MaterialProperty.FloatValue));
+
+            EditorGUI.PropertyField(position, propertyName);
+            position.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, propertyType);
+            position.y += EditorGUIUtility.singleLineHeight;
+
+            switch ((ShaderPropertyType)propertyType.enumValueIndex)
+            {
+                case ShaderPropertyType.Texture:
+                    EditorGUI.PropertyField(position, textureValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    EditorGUI.PropertyField(position, textureOffsetValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    EditorGUI.PropertyField(position, textureScaleValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    break;
+                case ShaderPropertyType.Color:
+                    EditorGUI.PropertyField(position, colorValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    break;
+                case ShaderPropertyType.Vector:
+                    Vector4 newValue = EditorGUI.Vector4Field(position, label, vectorValue.vector4Value);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        vectorValue.vector4Value = newValue;
+                    }
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    break;
+                case ShaderPropertyType.Int:
+                    EditorGUI.PropertyField(position, intValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    break;
+                case ShaderPropertyType.Float:
+                case ShaderPropertyType.Range:
+                    EditorGUI.PropertyField(position, floatValue);
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    break;
+            }
+
+            EditorGUI.EndProperty();
+        }
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {   
+            var height = EditorGUIUtility.singleLineHeight * 2;
+            var propertyType = property.FindPropertyRelative(nameof(MaterialProperty.PropertyType));
+            switch ((ShaderPropertyType)propertyType.enumValueIndex)
+            {
+                case ShaderPropertyType.Texture:
+                    height += EditorGUIUtility.singleLineHeight * 3;
+                    break;
+                case ShaderPropertyType.Color:
+                case ShaderPropertyType.Vector:
+                case ShaderPropertyType.Int:
+                case ShaderPropertyType.Float:
+                case ShaderPropertyType.Range:
+                    height += EditorGUIUtility.singleLineHeight;
+                    break;
+            }
+            return height;
+        }
+    }
+}

--- a/Editor/Inspector/MaterialOverrideTransferEditor.cs.meta
+++ b/Editor/Inspector/MaterialOverrideTransferEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d360a6d56a46cac4ebe7d6e457c971ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Common/MaterialProperty.cs
+++ b/Runtime/Common/MaterialProperty.cs
@@ -1,0 +1,149 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace net.rs64.TexTransTool
+{
+    [Serializable]
+    public struct MaterialProperty
+    {
+        public string PropertyName;
+        public ShaderPropertyType PropertyType;
+        
+        // ShaderPropertyType.Texture
+        public Texture TextureValue;
+        public Vector2 TextureOffsetValue;
+        public Vector2 TextureScaleValue; 
+        // ShaderPropertyType.Color
+        public Color ColorValue;
+        // ShaderPropertyType.Vector
+        public Vector4 VectorValue;
+        // ShaderPropertyType.Int
+        public int IntValue;
+        // ShaderPropertyType.Float, ShaderPropertyType.Range
+        public float FloatValue;
+
+        public bool Equals(MaterialProperty other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (PropertyType != other.PropertyType) return false;
+            if (PropertyName != other.PropertyName) return false;
+
+            switch (PropertyType)
+            {
+                case ShaderPropertyType.Texture:
+                    return TextureValue == other.TextureValue && TextureOffsetValue.Equals(other.TextureOffsetValue) && TextureScaleValue.Equals(other.TextureScaleValue);
+                case ShaderPropertyType.Color:
+                    return ColorValue.Equals(other.ColorValue);
+                case ShaderPropertyType.Vector:
+                    return VectorValue.Equals(other.VectorValue);
+                case ShaderPropertyType.Int:
+                    return IntValue == other.IntValue;
+                case ShaderPropertyType.Float:
+                case ShaderPropertyType.Range:
+                    return FloatValue.Equals(other.FloatValue);
+                default:
+                    return false;
+            }
+        }
+
+        public void Set(Material mat)
+        {
+            if (!Validiate(mat, PropertyName, PropertyType)) return;
+
+            switch (PropertyType)
+            {
+                case ShaderPropertyType.Texture:
+                    {
+                        mat.SetTexture(PropertyName, TextureValue);
+                        mat.SetTextureOffset(PropertyName, TextureOffsetValue);
+                        mat.SetTextureScale(PropertyName, TextureScaleValue);
+                        break;
+                    }
+                case ShaderPropertyType.Color:
+                    {
+                        mat.SetColor(PropertyName, ColorValue);
+                        break;
+                    }
+                case ShaderPropertyType.Vector:
+                    {
+                        mat.SetVector(PropertyName, VectorValue);
+                        break;
+                    }
+                case ShaderPropertyType.Int:
+                    {
+                        mat.SetInt(PropertyName, IntValue);
+                        break;
+                    }
+                case ShaderPropertyType.Float:
+                case ShaderPropertyType.Range:
+                    {
+                        mat.SetFloat(PropertyName, FloatValue);
+                        break;
+                    }
+            }
+        }
+
+        public static bool TryGet(Material mat, string propertyName, ShaderPropertyType propertyType, out MaterialProperty materialProperty)
+        {
+            materialProperty = default;
+
+            if (!Validiate(mat, propertyName, propertyType)) return false;
+
+            materialProperty = new MaterialProperty
+            {
+                PropertyName = propertyName,
+                PropertyType = propertyType
+            };
+
+            switch (propertyType)
+            {
+                case ShaderPropertyType.Texture:
+                    {
+                        materialProperty.TextureValue = mat.GetTexture(propertyName);
+                        materialProperty.TextureOffsetValue = mat.GetTextureOffset(propertyName);
+                        materialProperty.TextureScaleValue = mat.GetTextureScale(propertyName);
+                        break;
+                    }
+                case ShaderPropertyType.Color:
+                    {
+                        materialProperty.ColorValue = mat.GetColor(propertyName);
+                        break;
+                    }
+                case ShaderPropertyType.Vector:
+                    {
+                        materialProperty.VectorValue = mat.GetVector(propertyName);
+                        break;
+                    }
+                case ShaderPropertyType.Int:
+                    {
+                        materialProperty.IntValue = mat.GetInt(propertyName);
+                        break;
+                    }
+                case ShaderPropertyType.Float:
+                case ShaderPropertyType.Range:
+                    {
+                        materialProperty.FloatValue = mat.GetFloat(propertyName);
+                        break;
+                    }
+            }
+            return true;
+        }
+
+        private static bool Validiate(Material mat, string propertyName, ShaderPropertyType propertyType)
+        {
+            if (!mat.HasProperty(propertyName))
+            {
+                return false;
+            }
+            var propertyIndex = mat.shader.FindPropertyIndex(propertyName);
+            if(propertyIndex == -1 || mat.shader.GetPropertyType(propertyIndex) != propertyType)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Runtime/Common/MaterialProperty.cs.meta
+++ b/Runtime/Common/MaterialProperty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06267145a03c4c94ba21aa1775c12ef2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CommonComponent/MaterialOverrideTransfer.cs
+++ b/Runtime/CommonComponent/MaterialOverrideTransfer.cs
@@ -1,7 +1,14 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace net.rs64.TexTransTool
 {
+    public enum MaterialOverrideTransferMode
+    {
+        Variant,
+        Record
+    }
+
     [AddComponentMenu(TexTransBehavior.TTTName + "/" + MenuPath)]
     public sealed class MaterialOverrideTransfer : TexTransCallEditorBehavior
     {
@@ -11,6 +18,18 @@ namespace net.rs64.TexTransTool
         internal override TexTransPhase PhaseDefine => TexTransPhase.UnDefined;
 
         public Material TargetMaterial;
+
+        public MaterialOverrideTransferMode Mode = MaterialOverrideTransferMode.Variant;
+
+        // MaterialOverrideTransferMode.Variant
         public Material MaterialVariantSource;
+
+        // MaterialOverrideTransferMode.Record
+        public Shader OverrideShader;
+        public List<MaterialProperty> OverrideProperties = new();
+
+        // EditorにおけるRecording用
+        public bool IsRecording = false;
+        public Material TempMaterial;
     }
 }


### PR DESCRIPTION
従来のMaterial Variantを用いる手法の他に、その場でマテリアルを編集し、シェーダーの変更を含めたオーバーライドをコンポーネントで保持するモードを追加します。

気になる点は以下です。
・モードの初期値をどちらにすべきか(既存のコンポーネントを破壊しないために一旦Variant Modeにしました)
・IEditorProcessor.Processの実装内容(マテリアルの編集内容をPreviewに反映するために変な実装になったかもしれません)
・その他UIやモード名など