### PR TITLE
feat: NewGameObjectAndAddTTTComponent for Material

### DIFF
--- a/CHANGELOG-EXPERIMENTAL.md
+++ b/CHANGELOG-EXPERIMENTAL.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 一つの子となる IslandSelector を基に IslandSelect の範囲を広げて選択できる、 IslandSelectorLink系 コンポーネントが 4つ 追加されました (#777)
 - TTT PSD Importer に PSD ImportMode SAI が追加され、出力元が SAI であるとみられる場合に自動判定されるようになりました (#781)
 - マテリアルをその場で変更し差分をオーバーライドとして非破壊的に適用できる MaterialConfigurator が追加されました (#788)
+- マテリアルのコンテキストメニューから MaterialOverrideTransfer と MaterialConfigurator が追加できる MenuItem が追加されました (#792)
 
 ### Changed
 

--- a/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
+++ b/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
@@ -10,16 +10,25 @@ namespace net.rs64.TexTransTool.Editor.OtherMenuItem
 {
     internal class NewGameObjectAndAddTTTComponent
     {
-        static void C<TTB>() where TTB : MonoBehaviour
+        static TTB C<TTB>() where TTB : MonoBehaviour
         {
-            var parent = Selection.activeGameObject;
-            var newGameObj = new GameObject(typeof(TTB).Name);
-            newGameObj.transform.SetParent(parent?.transform, false);
-            newGameObj.AddComponent<TTB>();
-            Undo.RegisterCreatedObjectUndo(newGameObj, "Create " + typeof(TTB).Name);
+            var parent = Selection.activeGameObject?.transform;
+            if (parent == null) return null;
+            var component = C<TTB>(parent, typeof(TTB).Name);
+            Undo.RegisterCreatedObjectUndo(component.gameObject, "Create " + typeof(TTB).Name);
+            return component;
+        }
+
+        static TTB C<TTB>(Transform parent, string name) where TTB : MonoBehaviour
+        {
+            var newGameObj = new GameObject(name);
+            newGameObj.transform.SetParent(parent, false);
+            var newComponent = newGameObj.AddComponent<TTB>();
             Selection.activeGameObject = newGameObj;
             EditorGUIUtility.PingObject(newGameObj);
+            return newComponent;
         }
+
         const string GOPath = "GameObject";
         const string BP = GOPath + "/" + TexTransBehavior.TTTName + "/";
 

--- a/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
+++ b/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
@@ -88,6 +88,7 @@ namespace net.rs64.TexTransTool.Editor.OtherMenuItem
         }
 
         const string CPath = "CONTEXT";
+        // 四つ超えたら、 TexTransTool としてまとめてもよいかも
         const string MRP = CPath + "/" + nameof(Material) + "/";
         const int PRIORITY = 200;
         [M(MRP + MaterialOverrideTransfer.Name, false, PRIORITY)] static void MOTM(MenuCommand mc) => CM<MaterialOverrideTransfer>(mc, (c, m) => c.TargetMaterial = m);

--- a/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
+++ b/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using net.rs64.TexTransTool.Decal;
 using net.rs64.TexTransTool.IslandSelector;
 using net.rs64.TexTransTool.MultiLayerImage;
@@ -74,6 +75,23 @@ namespace net.rs64.TexTransTool.Editor.OtherMenuItem
         [M(BP + TextureBlender.MenuPath)] static void TB() => C<TextureBlender>();
         [M(BP + MaterialOverrideTransfer.MenuPath)] static void MOT() => C<MaterialOverrideTransfer>();
         [M(BP + MaterialConfigurator.MenuPath)] static void MC() => C<MaterialConfigurator>();
+
+        static void CM<TTB>(MenuCommand menuCommand, Action<TTB, Material> action = null) where TTB : MonoBehaviour
+        {
+            var material = menuCommand.context as Material;
+            var transform = Selection.activeGameObject?.transform;
+            if (transform == null) return;
+            var parent = transform.parent == null ? transform : transform.parent;
+            var component = C<TTB>(parent, material.name);
+            action?.Invoke(component, material);
+            Undo.RegisterCreatedObjectUndo(component.gameObject, "Create " + typeof(TTB).Name);
+        }
+
+        const string CPath = "CONTEXT";
+        const string MRP = CPath + "/" + nameof(Material) + "/";
+        const int PRIORITY = 200;
+        [M(MRP + MaterialOverrideTransfer.Name, false, PRIORITY)] static void MOTM(MenuCommand mc) => CM<MaterialOverrideTransfer>(mc, (c, m) => c.TargetMaterial = m);
+        [M(MRP + MaterialConfigurator.ComponentName, false, PRIORITY)] static void MCM(MenuCommand mc) => CM<MaterialConfigurator>(mc, (c, m) => c.TargetMaterial = m);
 
     }
 }

--- a/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
+++ b/Editor/OtherMenuItem/NewGameObjectAndAddTTTComponent.cs
@@ -91,7 +91,7 @@ namespace net.rs64.TexTransTool.Editor.OtherMenuItem
         // 四つ超えたら、 TexTransTool としてまとめてもよいかも
         const string MRP = CPath + "/" + nameof(Material) + "/";
         const int PRIORITY = 200;
-        [M(MRP + MaterialOverrideTransfer.Name, false, PRIORITY)] static void MOTM(MenuCommand mc) => CM<MaterialOverrideTransfer>(mc, (c, m) => c.TargetMaterial = m);
+        [M(MRP + MaterialOverrideTransfer.ComponentName, false, PRIORITY)] static void MOTM(MenuCommand mc) => CM<MaterialOverrideTransfer>(mc, (c, m) => c.TargetMaterial = m);
         [M(MRP + MaterialConfigurator.ComponentName, false, PRIORITY)] static void MCM(MenuCommand mc) => CM<MaterialConfigurator>(mc, (c, m) => c.TargetMaterial = m);
 
     }

--- a/Runtime/CommonComponent/MaterialOverrideTransfer.cs
+++ b/Runtime/CommonComponent/MaterialOverrideTransfer.cs
@@ -5,9 +5,9 @@ namespace net.rs64.TexTransTool
     [AddComponentMenu(TexTransBehavior.TTTName + "/" + MenuPath)]
     public sealed class MaterialOverrideTransfer : TexTransCallEditorBehavior
     {
-        internal const string Name = "TTT MaterialOverrideTransfer";
+        internal const string ComponentName = "TTT MaterialOverrideTransfer";
         internal const string FoldoutName = "Other";
-        internal const string MenuPath = FoldoutName + "/" + Name;
+        internal const string MenuPath = FoldoutName + "/" + ComponentName;
         internal override TexTransPhase PhaseDefine => TexTransPhase.UnDefined;
 
         public Material TargetMaterial;


### PR DESCRIPTION
既存のNewGameObjectAndAddTTTComponentの実行方法に加え、MaterialのCONTEXT MENUから実行する方法を追加するものです。MaterialConfiguratorの為に実装したので #788 が必要です。一旦MaterialOverrideTransferとMaterialConfiguratorに対して実装しました。

実行箇所の違いなどの他にコンポーネントに対するマテリアルの割り当てなども行うことで、より直接的に実行出来るようになると思います。

![image](https://github.com/user-attachments/assets/b229db5e-cb58-499a-9d00-2b6b94cacfeb)
