### PR TITLE
VRChat以外への対応宣言の追加

### DIFF
--- a/Editor/NDMF/NDMFPlugin.cs
+++ b/Editor/NDMF/NDMFPlugin.cs
@@ -1,12 +1,8 @@
 using nadena.dev.ndmf;
 using net.rs64.TexTransTool.NDMF;
-using net.rs64.TexTransTool.Build;
 using UnityEngine;
 using System.Collections.Generic;
 using nadena.dev.ndmf.preview;
-using System;
-using System.Linq;
-using net.rs64.TexTransCoreEngineForUnity;
 #if CONTAINS_AAO
 using net.rs64.TexTransTool.NDMF.AAO;
 #endif
@@ -16,6 +12,9 @@ using net.rs64.TexTransTool.NDMF.AAO;
 namespace net.rs64.TexTransTool.NDMF
 {
 
+    #if NDMF_1_8_0_OR_NEWER
+    [RunsOnAllPlatforms]
+    #endif
     internal class NDMFPlugin : Plugin<NDMFPlugin>
     {
         public override string QualifiedName => "net.rs64.tex-trans-tool";

--- a/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
+++ b/Editor/NDMF/net.rs64.tex-trans-tool.build.ndmf.asmdef
@@ -42,6 +42,11 @@
             "name": "nadena.dev.ndmf",
             "expression": "1.6.8",
             "define": "NDMF_1_6_8_OR_NEWER"
+        },
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "1.8.0-alpha.0",
+            "define": "NDMF_1_8_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
NDMF 1.8.0-alpha.0に追加された、[RunsOnAllPlatforms]宣言でVRChat以外
への対応を宣言することで、Resoniteなどのビルドでも動くようにする。

なお、このAPIに関するフィードバックを少しだけ待つので、マージはいったんお待ちください。