### PR TITLE
chore: load uss of DomainTextureSelector on initialization

### DIFF
--- a/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs
+++ b/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs
@@ -9,8 +9,7 @@ namespace net.rs64.TexTransTool.Editor
 {
     internal class DomainTextureSelector : EditorWindow
     {
-        private const string UIAssetsRoot = "Packages/net.rs64.tex-trans-tool/Editor/Inspector/UIAssets/";
-        private const string UssPath = UIAssetsRoot + "DomainTextureSelector.uss";
+        private const string USS_GUID = "bd819220d0758ca49b2e09633e5a778c";
 
         public static void OpenSelector(SerializedProperty textureProperty, Component component)
         {
@@ -29,7 +28,7 @@ namespace net.rs64.TexTransTool.Editor
             DomainContainsTextures = domainObject.GetComponentsInChildren<Renderer>(true)
             .SelectMany(i => i.sharedMaterials).SelectMany(i => i.GetAllTexture2DWithDictionary()).GroupBy(i => i.Key).ToDictionary(i => i.Key, i => i.Select(k => k.Value).Distinct().ToList());
 
-            var uss = AssetDatabase.LoadAssetAtPath<StyleSheet>(UssPath);
+            var uss = AssetDatabase.LoadAssetAtPath<StyleSheet>(AssetDatabase.GUIDToAssetPath(USS_GUID));
             rootVisualElement.styleSheets.Add(uss);
 
             var button = new Button(Close);

--- a/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs
+++ b/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs
@@ -9,7 +9,9 @@ namespace net.rs64.TexTransTool.Editor
 {
     internal class DomainTextureSelector : EditorWindow
     {
-        [SerializeField] StyleSheet styleSheet;
+        private const string UIAssetsRoot = "Packages/net.rs64.tex-trans-tool/Editor/Inspector/UIAssets/";
+        private const string UssPath = UIAssetsRoot + "DomainTextureSelector.uss";
+
         public static void OpenSelector(SerializedProperty textureProperty, Component component)
         {
             var window = GetWindow<DomainTextureSelector>();
@@ -21,13 +23,14 @@ namespace net.rs64.TexTransTool.Editor
         private void initialize(SerializedProperty textureProperty, Component component)
         {
             rootVisualElement.Clear();
-
+            
             TextureProperty = textureProperty;
             var domainObject = DomainMarkerFinder.FindMarker(component.gameObject);
             DomainContainsTextures = domainObject.GetComponentsInChildren<Renderer>(true)
             .SelectMany(i => i.sharedMaterials).SelectMany(i => i.GetAllTexture2DWithDictionary()).GroupBy(i => i.Key).ToDictionary(i => i.Key, i => i.Select(k => k.Value).Distinct().ToList());
 
-            rootVisualElement.styleSheets.Add(styleSheet);
+            var uss = AssetDatabase.LoadAssetAtPath<StyleSheet>(UssPath);
+            rootVisualElement.styleSheets.Add(uss);
 
             var button = new Button(Close);
             button.text = "Close";


### PR DESCRIPTION
何故か分かりませんがシリアライズされたstyleSheetが失われていて以下のエラーが発生していたので、初期化時にロードするように変更します。
```
ArgumentNullException: Value cannot be null.
Parameter name: styleSheet
UnityEngine.UIElements.VisualElementStyleSheetSet.Add (UnityEngine.UIElements.StyleSheet styleSheet) (at <332857d8803a4878904bcf8f9581ec33>:0)
net.rs64.TexTransTool.Editor.DomainTextureSelector.initialize (UnityEditor.SerializedProperty textureProperty, UnityEngine.Component component) (at ./Packages/TexTransTool/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs:30)
net.rs64.TexTransTool.Editor.DomainTextureSelector.OpenSelector (UnityEditor.SerializedProperty textureProperty, UnityEngine.Component component) (at ./Packages/TexTransTool/Editor/Inspector/CommonDrawer/DomainTextureSelector.cs:18)
net.rs64.TexTransTool.Editor.TextureSelectorDrawer.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at ./Packages/TexTransTool/Editor/Inspector/CommonDrawer/TextureSelectorDrawer.cs:24)
UnityEditor.PropertyDrawer.OnGUISafe (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEditor.PropertyHandler.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.Rect visibleArea) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEditor.PropertyHandler.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEditor.PropertyHandler.OnGUILayout (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, UnityEngine.GUILayoutOption[] options) (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
net.rs64.TexTransTool.Editor.ColorDifferenceChangerEditor.OnTexTransComponentInspectorGUI () (at ./Packages/TexTransTool/Editor/Inspector/CommonComponentEditor/ColorDifferenceChangerEditor.cs:11)
net.rs64.TexTransTool.Editor.TexTransMonoBaseEditor.OnInspectorGUI () (at ./Packages/TexTransTool/Editor/Inspector/TexTransMonoBaseEditor.cs:21)
net.rs64.TexTransTool.Editor.TTCanBehaveAsLayerEditor.OnInspectorGUI () (at ./Packages/TexTransTool/Editor/Inspector/TTCanBehaveAsLayerEditor.cs:32)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass72_0.<CreateInspectorElementUsingIMGUI>b__0 () (at <80a8ce1980c648dca8e68f0d8aa3b930>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```