### PR TITLE
feat: Localization for MultiLayerImageCanvas layers and improve UI

### DIFF
--- a/Editor/Inspector/MultiLayerImage/AbstractLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/AbstractLayerEditor.cs
@@ -67,11 +67,41 @@ namespace net.rs64.TexTransTool.Editor.MultiLayerImage
             _imageLayerPreviewResult.Value.domain.Dispose();
             _imageLayerPreviewResult = null;
         }
-        protected override void OnTexTransComponentInspectorGUI()
+        protected sealed override void OnTexTransComponentInspectorGUI()
         {
             EditorGUI.BeginChangeCheck();
-            base.OnTexTransComponentInspectorGUI();
+            DrawCommonProperties();
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+            DrawInnerProperties();
             _needUpdate |= EditorGUI.EndChangeCheck();
+        }
+
+        // GeneralCommonLayerSetting
+        protected void DrawCommonProperties()
+        {
+            var blendTypeKey = serializedObject.FindProperty(nameof(AbstractLayer.BlendTypeKey));
+            var opacity = serializedObject.FindProperty(nameof(AbstractLayer.Opacity));
+            var clipping = serializedObject.FindProperty(nameof(AbstractLayer.Clipping));
+            var layerMask = serializedObject.FindProperty(nameof(AbstractLayer.LayerMask));
+
+            EditorGUILayout.PropertyField(blendTypeKey, "AbstractLayer:prop:BlendTypeKey".Glc());
+            EditorGUILayout.PropertyField(opacity, "AbstractLayer:prop:Opacity".Glc());
+            EditorGUILayout.PropertyField(clipping, "AbstractLayer:prop:Clipping".Glc());
+            EditorGUILayout.PropertyField(layerMask, "AbstractLayer:prop:LayerMask".Glc());
+        }
+
+        protected virtual void DrawInnerProperties()
+        {
+            var iterator = serializedObject.GetIterator();
+            iterator.NextVisible(true); // m_script
+            for (int i = 0; i < 4; i++) // GeneralCommonLayerSetting
+            {
+                iterator.NextVisible(false);
+            }
+            while (iterator.NextVisible(false))
+            {
+                EditorGUILayout.PropertyField(iterator);
+            }
         }
 
         public override bool HasPreviewGUI() { return _imageLayerPreviewResult is not null; }

--- a/Editor/Inspector/MultiLayerImage/LayerFolderEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/LayerFolderEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(LayerFolder), true)]
+    [CanEditMultipleObjects]
+    internal class LayerFolderEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var passThrough = serializedObject.FindProperty(nameof(LayerFolder.PassThrough));
+            EditorGUILayout.PropertyField(passThrough, "LayerFolder:prop:PassThrough".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/LayerFolderEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/LayerFolderEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0a92f018e493fc4da21a5f43e03a1e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/RasterImportedLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/RasterImportedLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(RasterImportedLayer), true)]
+    [CanEditMultipleObjects]
+    internal class RasterImportedLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var importedImage = serializedObject.FindProperty(nameof(RasterImportedLayer.ImportedImage));
+            EditorGUILayout.PropertyField(importedImage, "RasterImportedLayer:prop:ImportedImage".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/RasterImportedLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/RasterImportedLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b652a5e411991b141883b5764481411c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/RasterLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/RasterLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(RasterLayer), true)]
+    [CanEditMultipleObjects]
+    internal class RasterLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var importedImage = serializedObject.FindProperty(nameof(RasterLayer.RasterTexture));
+            EditorGUILayout.PropertyField(importedImage, "RasterLayer:prop:RasterTexture".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/RasterLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/RasterLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7090917d493785249bafe1717748429f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46f87812d0f67104ea7cedf951891c43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/ColorizeLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/ColorizeLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(ColorizeLayer), true)]
+    [CanEditMultipleObjects]
+    internal class ColorizeLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var color = serializedObject.FindProperty(nameof(ColorizeLayer.Color));
+            EditorGUILayout.PropertyField(color, "ColorizeLayer:prop:Color".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/ColorizeLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/ColorizeLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e4c237e2559ff54fb52d42587ef8038
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/HSLAdjustmentLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/HSLAdjustmentLayerEditor.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(HSLAdjustmentLayer), true)]
+    [CanEditMultipleObjects]
+    internal class HSLAdjustmentLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var hue = serializedObject.FindProperty(nameof(HSLAdjustmentLayer.Hue));
+            EditorGUILayout.PropertyField(hue, "HSLAdjustmentLayer:prop:Hue".Glc());
+            var saturation = serializedObject.FindProperty(nameof(HSLAdjustmentLayer.Saturation));
+            EditorGUILayout.PropertyField(saturation, "HSLAdjustmentLayer:prop:Saturation".Glc());
+            var lightness = serializedObject.FindProperty(nameof(HSLAdjustmentLayer.Lightness));
+            EditorGUILayout.PropertyField(lightness, "HSLAdjustmentLayer:prop:Lightness".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/HSLAdjustmentLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/HSLAdjustmentLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33b564565f897b84ca2d91d9af90a0a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/HSVAdjustmentLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/HSVAdjustmentLayerEditor.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(HSVAdjustmentLayer), true)]
+    [CanEditMultipleObjects]
+    internal class HSVAdjustmentLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var hue = serializedObject.FindProperty(nameof(HSVAdjustmentLayer.Hue));
+            EditorGUILayout.PropertyField(hue, "HSVAdjustmentLayer:prop:Hue".Glc());
+            var saturation = serializedObject.FindProperty(nameof(HSVAdjustmentLayer.Saturation));
+            EditorGUILayout.PropertyField(saturation, "HSVAdjustmentLayer:prop:Saturation".Glc());
+            var value = serializedObject.FindProperty(nameof(HSVAdjustmentLayer.Value));
+            EditorGUILayout.PropertyField(value, "HSVAdjustmentLayer:prop:Value".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/HSVAdjustmentLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/HSVAdjustmentLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8155c7fc30b6a1c44bbf14742bb7dbc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/LevelAdjustmentLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/LevelAdjustmentLayerEditor.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+using UnityEngine;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(LevelAdjustmentLayer), true)]
+    [CanEditMultipleObjects]
+    internal class LevelAdjustmentLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var rgb = serializedObject.FindProperty(nameof(LevelAdjustmentLayer.RGB));
+            EditorGUILayout.PropertyField(rgb, "LevelAdjustmentLayer:prop:RGB".Glc());
+            var red = serializedObject.FindProperty(nameof(LevelAdjustmentLayer.Red));
+            EditorGUILayout.PropertyField(red, "LevelAdjustmentLayer:prop:Red".Glc());
+            var green = serializedObject.FindProperty(nameof(LevelAdjustmentLayer.Green));
+            EditorGUILayout.PropertyField(green, "LevelAdjustmentLayer:prop:Green".Glc());
+            var blue = serializedObject.FindProperty(nameof(LevelAdjustmentLayer.Blue));
+            EditorGUILayout.PropertyField(blue, "LevelAdjustmentLayer:prop:Blue".Glc());
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(LevelAdjustmentLayer.Level))]
+    internal class LevelDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            var currentPosition = position;
+            currentPosition.height = EditorGUIUtility.singleLineHeight;
+
+            EditorGUI.LabelField(currentPosition, label, EditorStyles.boldLabel);
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+
+            var inputFloor = property.FindPropertyRelative(nameof(LevelAdjustmentLayer.Level.InputFloor));
+            var inputCeiling = property.FindPropertyRelative(nameof(LevelAdjustmentLayer.Level.InputCeiling));
+            var gamma = property.FindPropertyRelative(nameof(LevelAdjustmentLayer.Level.Gamma));
+            var outputFloor = property.FindPropertyRelative(nameof(LevelAdjustmentLayer.Level.OutputFloor));
+            var outputCeiling = property.FindPropertyRelative(nameof(LevelAdjustmentLayer.Level.OutputCeiling));
+            
+            EditorGUI.indentLevel++;
+
+            EditorGUI.PropertyField(currentPosition, inputFloor, "LevelAdjustmentLayer:prop:InputFloor".Glc());
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(currentPosition, inputCeiling, "LevelAdjustmentLayer:prop:InputCeiling".Glc());
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(currentPosition, gamma, "LevelAdjustmentLayer:prop:Gamma".Glc());
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(currentPosition, outputFloor, "LevelAdjustmentLayer:prop:OutputFloor".Glc());
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(currentPosition, outputCeiling, "LevelAdjustmentLayer:prop:OutputCeiling".Glc());
+            currentPosition.y += EditorGUIUtility.singleLineHeight;
+            
+            EditorGUI.indentLevel--;
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight * 6;
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/LevelAdjustmentLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/LevelAdjustmentLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff326f5021a0f3f4eac632e57483d7b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/PhotoshopGradationMapLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/PhotoshopGradationMapLayerEditor.cs
@@ -1,0 +1,99 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+using UnityEngine;
+using System.Linq;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(PhotoshopGradationMapLayer), true)]
+    [CanEditMultipleObjects]
+    internal class PhotoshopGradationMapLayerEditor : AbstractLayerEditor
+    {
+        private static readonly string[] _gradientInteropMethodKeys = new string[] {
+            "PhotoshopGradationMapLayer:GradientInteropMethod:Classic",
+            "PhotoshopGradationMapLayer:GradientInteropMethod:Perceptual",
+            "PhotoshopGradationMapLayer:GradientInteropMethod:Linear",
+            "PhotoshopGradationMapLayer:GradientInteropMethod:Smooth",
+            "PhotoshopGradationMapLayer:GradientInteropMethod:Stripes",
+        };
+
+        protected override void DrawInnerProperties()
+        {
+            var isGradientReversed = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.IsGradientReversed));
+            EditorGUILayout.PropertyField(isGradientReversed, "PhotoshopGradationMapLayer:prop:IsGradientReversed".Glc());
+            var isGradientDithered = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.IsGradientDithered));
+            EditorGUILayout.PropertyField(isGradientDithered, "PhotoshopGradationMapLayer:prop:IsGradientDithered".Glc());
+
+            var interopMethod = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.InteropMethod));
+            var interopMethodContents = _gradientInteropMethodKeys.Select(i => i.Glc()).ToArray();
+            interopMethod.enumValueIndex = EditorGUILayout.Popup("PhotoshopGradationMapLayer:prop:InteropMethod".Glc(), interopMethod.enumValueIndex, interopMethodContents);
+
+            var smoothens = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.Smoothens));
+            EditorGUILayout.PropertyField(smoothens, "PhotoshopGradationMapLayer:prop:Smoothens".Glc());
+            var colorKeys = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.ColorKeys));
+            EditorGUILayout.PropertyField(colorKeys, "PhotoshopGradationMapLayer:prop:ColorKeys".Glc());
+            var transparencyKeys = serializedObject.FindProperty(nameof(PhotoshopGradationMapLayer.TransparencyKeys));
+            EditorGUILayout.PropertyField(transparencyKeys, "PhotoshopGradationMapLayer:prop:TransparencyKeys".Glc());
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(PhotoshopGradationMapLayer.ColorKey))]
+    internal class ColorKeyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+            
+            var keyLocation = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.ColorKey.KeyLocation));
+            var midLocation = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.ColorKey.MidLocation));
+            var color = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.ColorKey.Color));
+            
+            position.height = EditorGUIUtility.singleLineHeight;
+
+            EditorGUI.PropertyField(position, keyLocation, "PhotoshopGradationMapLayer:prop:KeyLocation".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, midLocation, "PhotoshopGradationMapLayer:prop:MidLocation".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, color, "PhotoshopGradationMapLayer:prop:Color".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight * 3;
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(PhotoshopGradationMapLayer.TransparencyKey))]
+    internal class TransparencyKeyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+            
+            var keyLocation = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.TransparencyKey.KeyLocation));
+            var midLocation = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.TransparencyKey.MidLocation));
+            var transparency = property.FindPropertyRelative(nameof(PhotoshopGradationMapLayer.TransparencyKey.Transparency));
+
+            position.height = EditorGUIUtility.singleLineHeight;
+
+            EditorGUI.PropertyField(position, keyLocation, "PhotoshopGradationMapLayer:prop:KeyLocation".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, midLocation, "PhotoshopGradationMapLayer:prop:MidLocation".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(position, transparency, "PhotoshopGradationMapLayer:prop:Transparency".Glc());
+            position.y += EditorGUIUtility.singleLineHeight;
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight * 3;
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/PhotoshopGradationMapLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/PhotoshopGradationMapLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71ca27b9004854943ac5fed401cf3b26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/SelectiveColoringAdjustmentLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/SelectiveColoringAdjustmentLayerEditor.cs
@@ -1,0 +1,67 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+using UnityEngine;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(SelectiveColoringAdjustmentLayer), true)]
+    [CanEditMultipleObjects]
+    internal class SelectiveColoringAdjustmentLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.LabelField("SelectiveColoringAdjustmentLayer:label:CMYK".Glc(), EditorStyles.boldLabel);
+
+            EditorGUILayout.Space();
+
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:RedsCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.RedsCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:YellowsCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.YellowsCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:GreensCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.GreensCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:CyansCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.CyansCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:BluesCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.BluesCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:MagentasCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.MagentasCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:WhitesCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.WhitesCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:NeutralsCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.NeutralsCMYK));
+            DrawCMYKProperty("SelectiveColoringAdjustmentLayer:label:BlacksCMYK".Glc(), nameof(SelectiveColoringAdjustmentLayer.BlacksCMYK));
+            
+            EditorGUILayout.Space();
+
+            var isAbsolute = serializedObject.FindProperty(nameof(SelectiveColoringAdjustmentLayer.IsAbsolute));
+            EditorGUILayout.PropertyField(isAbsolute, "SelectiveColoringAdjustmentLayer:prop:IsAbsolute".Glc());
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawCMYKProperty(GUIContent label, string propertyName)
+        {
+            var property = serializedObject.FindProperty(propertyName);
+            var vector = property.vector4Value;
+            
+            // 境界を分かりやすくするためのボックス
+            EditorGUILayout.BeginVertical("helpbox");
+            
+            EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
+
+            var padding = 5;
+                        
+            EditorGUILayout.BeginHorizontal();
+            vector.x = EditorGUILayout.Slider(vector.x, -1f, 1f);
+            EditorGUILayout.Space(padding);
+            vector.y = EditorGUILayout.Slider(vector.y, -1f, 1f);
+            EditorGUILayout.Space(padding);
+            vector.z = EditorGUILayout.Slider(vector.z, -1f, 1f);
+            EditorGUILayout.Space(padding);
+            vector.w = EditorGUILayout.Slider(vector.w, -1f, 1f);
+            EditorGUILayout.EndHorizontal();
+            
+            property.vector4Value = vector;
+                        
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.Space(2);
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/SelectiveColoringAdjustmentLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/SelectiveColoringAdjustmentLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4047766079f493945923ee7252474cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/SolidColorLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/SolidColorLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(SolidColorLayer), true)]
+    [CanEditMultipleObjects]
+    internal class SolidColorLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var color = serializedObject.FindProperty(nameof(SolidColorLayer.Color));
+            EditorGUILayout.PropertyField(color, "SolidColorLayer:prop:Color".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/SolidColorLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/SolidColorLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eed631d7e06fae941b31422ce9d3a2d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/UnityGradationMapLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/UnityGradationMapLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(UnityGradationMapLayer), true)]
+    [CanEditMultipleObjects]
+    internal class UnityGradationMapLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var gradation = serializedObject.FindProperty(nameof(UnityGradationMapLayer.Gradation));
+            EditorGUILayout.PropertyField(gradation, "UnityGradationMapLayer:prop:Gradation".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/UnityGradationMapLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/UnityGradationMapLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42ee7ba0ef218ac49a04439446a60c5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/YAxisFixedGradientLayerEditor.cs
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/YAxisFixedGradientLayerEditor.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using UnityEditor;
+using net.rs64.TexTransTool.MultiLayerImage;
+
+namespace net.rs64.TexTransTool.Editor.MultiLayerImage
+{
+    [CustomEditor(typeof(YAxisFixedGradientLayer), true)]
+    [CanEditMultipleObjects]
+    internal class YAxisFixedGradientLayerEditor : AbstractLayerEditor
+    {
+        protected override void DrawInnerProperties()
+        {
+            var gradient = serializedObject.FindProperty(nameof(YAxisFixedGradientLayer.Gradient));
+            EditorGUILayout.PropertyField(gradient, "YAxisFixedGradientLayer:prop:Gradient".Glc());
+        }
+    }
+}

--- a/Editor/Inspector/MultiLayerImage/SpecialLayer/YAxisFixedGradientLayerEditor.cs.meta
+++ b/Editor/Inspector/MultiLayerImage/SpecialLayer/YAxisFixedGradientLayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b306da223e18cee4d97073a61a230f61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Localize/en_US.po
+++ b/Editor/Localize/en_US.po
@@ -686,6 +686,190 @@ msgstr "Target not set!"
 msgid "MultiLayerImageCanvas:info:TargetNotFound"
 msgstr "Target not found!"
 
+# AbstractLayer
+
+msgid "AbstractLayer:prop:Opacity"
+msgstr "Opacity"
+
+msgid "AbstractLayer:prop:Clipping"
+msgstr "Clipping"
+
+msgid "AbstractLayer:prop:BlendTypeKey"
+msgstr "Blend Type Key"
+
+msgid "AbstractLayer:prop:LayerMask"
+msgstr "Layer Mask"
+
+# LayerFolder
+
+msgid "LayerFolder:prop:PassThrough"
+msgstr "Pass Through"
+
+# RasterImportedLayer
+
+msgid "RasterImportedLayer:prop:ImportedImage"
+msgstr "Imported Texture"
+
+# RasterLayer
+
+msgid "RasterLayer:prop:RasterTexture"
+msgstr "Texture"
+
+# ColorizeLayer
+
+msgid "ColorizeLayer:prop:Color"
+msgstr "Color"
+
+# HSLAdjustmentLayer
+
+msgid "HSLAdjustmentLayer:prop:Hue"
+msgstr "Hue"
+
+msgid "HSLAdjustmentLayer:prop:Saturation"
+msgstr "Saturation"
+
+msgid "HSLAdjustmentLayer:prop:Lightness"
+msgstr "Lightness"
+
+# HSVAdjustmentLayer
+
+msgid "HSVAdjustmentLayer:prop:Hue"
+msgstr "Hue"
+
+msgid "HSVAdjustmentLayer:prop:Saturation"
+msgstr "Saturation"
+
+msgid "HSVAdjustmentLayer:prop:Value"
+msgstr "Value"
+
+# LevelAdjustmentLayer
+
+msgid "LevelAdjustmentLayer:prop:RGB"
+msgstr "RGB"
+
+msgid "LevelAdjustmentLayer:prop:Red"
+msgstr "Red"
+
+msgid "LevelAdjustmentLayer:prop:Green"
+msgstr "Green"
+
+msgid "LevelAdjustmentLayer:prop:Blue"
+msgstr "Blue"
+
+msgid "LevelAdjustmentLayer:prop:InputFloor"
+msgstr "Input Minimum"
+
+msgid "LevelAdjustmentLayer:prop:InputCeiling"
+msgstr "Input Maximum"
+
+msgid "LevelAdjustmentLayer:prop:Gamma"
+msgstr "Gamma"
+
+msgid "LevelAdjustmentLayer:prop:OutputFloor"
+msgstr "Output Minimum"
+
+msgid "LevelAdjustmentLayer:prop:OutputCeiling"
+msgstr "Output Maximum"
+
+# PhotoshopGradationMapLayer
+
+msgid "PhotoshopGradationMapLayer:prop:IsGradientReversed"
+msgstr "Reverse Gradient"
+
+msgid "PhotoshopGradationMapLayer:prop:IsGradientDithered"
+msgstr "Dither Gradient"
+
+msgid "PhotoshopGradationMapLayer:prop:InteropMethod"
+msgstr "Gradient Interpolation Method"
+
+msgid "PhotoshopGradationMapLayer:prop:Smoothens"
+msgstr "Smooth Gradient"
+
+msgid "PhotoshopGradationMapLayer:prop:ColorKeys"
+msgstr "Color Keys"
+
+msgid "PhotoshopGradationMapLayer:prop:TransparencyKeys"
+msgstr "Transparency Keys"
+
+msgid "PhotoshopGradationMapLayer:prop:KeyLocation"
+msgstr "Key Position"
+
+msgid "PhotoshopGradationMapLayer:prop:MidLocation"
+msgstr "Midpoint Position"
+
+msgid "PhotoshopGradationMapLayer:prop:Color"
+msgstr "Color"
+
+msgid "PhotoshopGradationMapLayer:prop:Transparency"
+msgstr "Transparency"
+
+# PhotoshopGradationMapLayer:GradientInteropMethod
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Classic"
+msgstr "Classic"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Perceptual"
+msgstr "Perceptual"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Linear"
+msgstr "Linear"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Smooth"
+msgstr "Smooth"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Stripes"
+msgstr "Stripes"
+
+# SelectiveColoringAdjustmentLayer
+
+msgid "SelectiveColoringAdjustmentLayer:label:CMYK"
+msgstr "CMYK (Cyan, Magenta, Yellow, Black)"
+
+msgid "SelectiveColoringAdjustmentLayer:label:RedsCMYK"
+msgstr "Red"
+
+msgid "SelectiveColoringAdjustmentLayer:label:YellowsCMYK"
+msgstr "Yellow"
+
+msgid "SelectiveColoringAdjustmentLayer:label:GreensCMYK"
+msgstr "Green"
+
+msgid "SelectiveColoringAdjustmentLayer:label:CyansCMYK"
+msgstr "Cyan"
+
+msgid "SelectiveColoringAdjustmentLayer:label:BluesCMYK"
+msgstr "Blue"
+
+msgid "SelectiveColoringAdjustmentLayer:label:MagentasCMYK"
+msgstr "Magenta"
+
+msgid "SelectiveColoringAdjustmentLayer:label:WhitesCMYK"
+msgstr "White"
+
+msgid "SelectiveColoringAdjustmentLayer:label:NeutralsCMYK"
+msgstr "Neutral"
+
+msgid "SelectiveColoringAdjustmentLayer:label:BlacksCMYK"
+msgstr "Black"
+
+msgid "SelectiveColoringAdjustmentLayer:prop:IsAbsolute"
+msgstr "Apply as Absolute Value"
+
+# SolidColorLayer
+
+msgid "SolidColorLayer:prop:Color"
+msgstr "Fill Color"
+
+# UnityGradationMapLayer
+
+msgid "UnityGradationMapLayer:prop:Gradation"
+msgstr "Gradation"
+
+# YAxisFixedGradientLayer
+
+msgid "YAxisFixedGradientLayer:prop:Gradient"
+msgstr "Gradient"
+
 # NegotiateAAO
 
 msgid "NegotiateAAO:warn:UVEvacuationFailed"

--- a/Editor/Localize/ja_JP.po
+++ b/Editor/Localize/ja_JP.po
@@ -682,6 +682,190 @@ msgstr "適用対象が設定されていません！"
 msgid "MultiLayerImageCanvas:info:TargetNotFound"
 msgstr "適用対象が存在しません！"
 
+# AbstractLayer
+
+msgid "AbstractLayer:prop:Opacity"
+msgstr "透明度"
+
+msgid "AbstractLayer:prop:Clipping"
+msgstr "クリッピング"
+
+msgid "AbstractLayer:prop:BlendTypeKey"
+msgstr "ブレンドタイプキー"
+
+msgid "AbstractLayer:prop:LayerMask"
+msgstr "レイヤーマスク"
+
+# LayerFolder
+
+msgid "LayerFolder:prop:PassThrough"
+msgstr "パススルー"
+
+# RasterImportedLayer
+
+msgid "RasterImportedLayer:prop:ImportedImage"
+msgstr "インポートされたテクスチャー"
+
+# RasterLayer
+
+msgid "RasterLayer:prop:RasterTexture"
+msgstr "テクスチャー"
+
+# ColorizeLayer
+
+msgid "ColorizeLayer:prop:Color"
+msgstr "色"
+
+# HSLAdjustmentLayer
+
+msgid "HSLAdjustmentLayer:prop:Hue"
+msgstr "色相"
+
+msgid "HSLAdjustmentLayer:prop:Saturation"
+msgstr "彩度"
+
+msgid "HSLAdjustmentLayer:prop:Lightness"
+msgstr "輝度"
+
+# HSVAdjustmentLayer
+
+msgid "HSVAdjustmentLayer:prop:Hue"
+msgstr "色相"
+
+msgid "HSVAdjustmentLayer:prop:Saturation"
+msgstr "彩度"
+
+msgid "HSVAdjustmentLayer:prop:Value"
+msgstr "明度"
+
+# LevelAdjustmentLayer
+
+msgid "LevelAdjustmentLayer:prop:RGB"
+msgstr "RGB"
+
+msgid "LevelAdjustmentLayer:prop:Red"
+msgstr "赤"
+
+msgid "LevelAdjustmentLayer:prop:Green"
+msgstr "緑"
+
+msgid "LevelAdjustmentLayer:prop:Blue"
+msgstr "青"
+
+msgid "LevelAdjustmentLayer:prop:InputFloor"
+msgstr "入力の下限"
+
+msgid "LevelAdjustmentLayer:prop:InputCeiling"
+msgstr "入力の上限"
+
+msgid "LevelAdjustmentLayer:prop:Gamma"
+msgstr "ガンマ"
+
+msgid "LevelAdjustmentLayer:prop:OutputFloor"
+msgstr "出力の下限"
+
+msgid "LevelAdjustmentLayer:prop:OutputCeiling"
+msgstr "出力の上限"
+
+# PhotoshopGradationMapLayer
+
+msgid "PhotoshopGradationMapLayer:prop:IsGradientReversed"
+msgstr "グラデーションを反転する"
+
+msgid "PhotoshopGradationMapLayer:prop:IsGradientDithered"
+msgstr "グラデーションをディザリングする"
+
+msgid "PhotoshopGradationMapLayer:prop:InteropMethod"
+msgstr "グラデーション補間方式"
+
+msgid "PhotoshopGradationMapLayer:prop:Smoothens"
+msgstr "グラデーションを平滑化する"
+
+msgid "PhotoshopGradationMapLayer:prop:ColorKeys"
+msgstr "色キー"
+
+msgid "PhotoshopGradationMapLayer:prop:TransparencyKeys"
+msgstr "透明度キー"
+
+msgid "PhotoshopGradationMapLayer:prop:KeyLocation"
+msgstr "キー位置"
+
+msgid "PhotoshopGradationMapLayer:prop:MidLocation"
+msgstr "中間位置"
+
+msgid "PhotoshopGradationMapLayer:prop:Color"
+msgstr "色"
+
+msgid "PhotoshopGradationMapLayer:prop:Transparency"
+msgstr "透明度"
+
+# PhotoshopGradationMapLayer:GradientInteropMethod
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Classic"
+msgstr "クラシック"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Perceptual"
+msgstr "知覚的"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Linear"
+msgstr "線形"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Smooth"
+msgstr "スムーズ"
+
+msgid "PhotoshopGradationMapLayer:GradientInteropMethod:Stripes"
+msgstr "ストライプ"
+
+# SelectiveColoringAdjustmentLayer
+
+msgid "SelectiveColoringAdjustmentLayer:label:CMYK"
+msgstr "CMYK (シアン・マゼンダ・イエロー・ブラック)"
+
+msgid "SelectiveColoringAdjustmentLayer:label:RedsCMYK"
+msgstr "赤"
+
+msgid "SelectiveColoringAdjustmentLayer:label:YellowsCMYK"
+msgstr "黄"
+
+msgid "SelectiveColoringAdjustmentLayer:label:GreensCMYK"
+msgstr "緑"
+
+msgid "SelectiveColoringAdjustmentLayer:label:CyansCMYK"
+msgstr "シアン"
+
+msgid "SelectiveColoringAdjustmentLayer:label:BluesCMYK"
+msgstr "青"
+
+msgid "SelectiveColoringAdjustmentLayer:label:MagentasCMYK"
+msgstr "マゼンダ"
+
+msgid "SelectiveColoringAdjustmentLayer:label:WhitesCMYK"
+msgstr "白"
+
+msgid "SelectiveColoringAdjustmentLayer:label:NeutralsCMYK"
+msgstr "中性"
+
+msgid "SelectiveColoringAdjustmentLayer:label:BlacksCMYK"
+msgstr "黒"
+
+msgid "SelectiveColoringAdjustmentLayer:prop:IsAbsolute"
+msgstr "絶対値として適用する"
+
+# SolidColorLayer
+
+msgid "SolidColorLayer:prop:Color"
+msgstr "べた塗りする色"
+
+# UnityGradationMapLayer
+
+msgid "UnityGradationMapLayer:prop:Gradation"
+msgstr "グラデーション"
+
+# YAxisFixedGradientLayer
+
+msgid "YAxisFixedGradientLayer:prop:Gradient"
+msgstr "グラデーション"
+
 # NegotiateAAO
 
 msgid "NegotiateAAO:warn:UVEvacuationFailed"


### PR DESCRIPTION
MLICの全レイヤーに対して、日本語のローカライズを追加します。
また、SelectiveColoringAdjustmentLayerとLevelAdjustmentLayerに関してはデフォルトの描画が操作性に欠くと思われたため、UIを変更しています。

ローカライズに関してはLayerMaskのみSerializeReference/SubclassSelectorであり適用が大変そうだったので一旦行っていませんが、それ以外は全プロパティが適用されているはずです。